### PR TITLE
Fixed bug when loading dictionaries with $INCLUDE using base classpath.

### DIFF
--- a/src/main/java/org/tinyradius/core/dictionary/parser/resolver/ClasspathResourceResolver.java
+++ b/src/main/java/org/tinyradius/core/dictionary/parser/resolver/ClasspathResourceResolver.java
@@ -13,7 +13,11 @@ public class ClasspathResourceResolver implements ResourceResolver {
 
     @Override
     public String resolve(String currentResource, String nextResource) {
-        final String path = Paths.get(currentResource).getParent().resolve(nextResource).toString();
+
+        final String path = Paths.get(currentResource).getParent() != null
+          ? Paths.get(currentResource).getParent().resolve(nextResource).toString()
+          : Paths.get(nextResource).toString();
+
         return this.getClass().getClassLoader().getResource(path) != null ?
                 path : "";
     }


### PR DESCRIPTION
Fixed a bug when $INCLUDE with a dictionary file in the jar resource classpath when not inside a sub directory.