### PR TITLE
A small enhancement to how the radius secret is obtained.

### DIFF
--- a/src/main/java/org/tinyradius/io/server/SecretProvider.java
+++ b/src/main/java/org/tinyradius/io/server/SecretProvider.java
@@ -2,6 +2,8 @@ package org.tinyradius.io.server;
 
 import java.net.InetSocketAddress;
 
+import org.tinyradius.core.packet.request.RadiusRequest;
+
 public interface SecretProvider {
 
     /**
@@ -12,5 +14,17 @@ public interface SecretProvider {
      * @return shared secret or null
      */
     String getSharedSecret(InetSocketAddress address);
+    
+    /**
+     * An alternative method of returning shared secret but this time with the current
+     * radius request so that alternative secrets can be returned based on some sort of 
+     * context. 
+     * 
+     * By default this method calls the original getSharedSecret.
+     * @param address
+     * @param request
+     * @return
+     */
+    default String getSharedSecret(InetSocketAddress address, RadiusRequest request) { return getSharedSecret(address); }
 
 }

--- a/src/main/java/org/tinyradius/io/server/SecretProvider.java
+++ b/src/main/java/org/tinyradius/io/server/SecretProvider.java
@@ -6,25 +6,28 @@ import org.tinyradius.core.packet.request.RadiusRequest;
 
 public interface SecretProvider {
 
-    /**
-     * Returns the shared secret used to communicate with the client/host with the
-     * passed IP address or null if the client is not allowed at this server.
-     *
-     * @param address IP address and port number of remote host/client
-     * @return shared secret or null
-     */
-    String getSharedSecret(InetSocketAddress address);
-    
-    /**
-     * An alternative method of returning shared secret but this time with the current
-     * radius request so that alternative secrets can be returned based on some sort of 
-     * context. 
-     * 
-     * By default this method calls the original getSharedSecret.
-     * @param address
-     * @param request
-     * @return
-     */
-    default String getSharedSecret(InetSocketAddress address, RadiusRequest request) { return getSharedSecret(address); }
+	/**
+	 * Returns the shared secret used to communicate with the client/host with the
+	 * passed IP address or null if the client is not allowed at this server.
+	 *
+	 * @param address IP address and port number of remote host/client
+	 * @return shared secret or null
+	 */
+	String getSharedSecret(InetSocketAddress address);
+
+	/**
+	 * An alternative method of returning shared secret but this time with the
+	 * current radius request so that alternative secrets can be returned based on
+	 * some sort of context.
+	 * 
+	 * By default this method calls the original getSharedSecret.
+	 * 
+	 * @param address IP address and port number of remote host/client
+	 * @param request the RadiusRequest relating to this request
+	 * @return shared secret or null
+	 */
+	default String getSharedSecret(InetSocketAddress address, RadiusRequest request) {
+		return getSharedSecret(address);
+	}
 
 }

--- a/src/main/java/org/tinyradius/io/server/handler/ServerPacketCodec.java
+++ b/src/main/java/org/tinyradius/io/server/handler/ServerPacketCodec.java
@@ -57,14 +57,15 @@ public class ServerPacketCodec extends MessageToMessageCodec<DatagramPacket, Res
     protected void decode(ChannelHandlerContext ctx, DatagramPacket msg, List<Object> out) {
         final InetSocketAddress remoteAddress = msg.sender();
 
-        String secret = secretProvider.getSharedSecret(remoteAddress);
-        if (secret == null) {
-            logger.warn("Ignoring packet from {}, shared secret lookup failed", remoteAddress);
-            return;
-        }
-
         try {
             final RadiusRequest request = fromDatagram(dictionary, msg);
+            
+            String secret = secretProvider.getSharedSecret(remoteAddress, request);
+            if (secret == null) {
+                logger.warn("Ignoring packet from {}, shared secret lookup failed", remoteAddress);
+                return;
+            }
+            
             logger.debug("Received request from {} - {}", remoteAddress, request);
             // log first before errors may be thrown
 


### PR DESCRIPTION
Now, the RadiusRequest is passed to getSharedSecret so that the implementation can return different secrets based on some context of the request. In my requirement, I have a single radius port authenticating different user domains and I need separate secrets per domain. This change enables support for this, whilst retaining backward compatibility for others by introducing a new method on SecretProvider that has a default implementation to call the original method. Implementations can then decide which strategy they require.