### PR TITLE
Test fix for RadiusServer

### DIFF
--- a/src/test/java/org/tinyradius/io/TestServer.java
+++ b/src/test/java/org/tinyradius/io/TestServer.java
@@ -15,6 +15,7 @@ import org.tinyradius.core.RadiusPacketException;
 import org.tinyradius.core.dictionary.DefaultDictionary;
 import org.tinyradius.core.dictionary.Dictionary;
 import org.tinyradius.core.packet.request.AccessRequest;
+import org.tinyradius.core.packet.request.AccountingRequest;
 import org.tinyradius.core.packet.request.AccessRequestPap;
 import org.tinyradius.core.packet.request.RadiusRequest;
 import org.tinyradius.core.packet.response.RadiusResponse;
@@ -117,7 +118,7 @@ public class TestServer {
 
         @Override
         protected Class<? extends RadiusRequest> acceptedPacketType() {
-            return AccessRequest.class;
+            return AccountingRequest.class;
         }
 
         @Override


### PR DESCRIPTION
Radius server implementation on test was trying to handle accounting messages but the supported message type was set to AccessRequest. It is fixed to match with accounting request. 