### PR TITLE
Reducing dependencies on netty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
     implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
-    implementation 'io.netty:netty-all:4.1.76.Final'
+    implementation 'io.netty:netty-codec:4.1.76.Final'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
     testImplementation 'org.apache.logging.log4j:log4j-core:2.17.2'


### PR DESCRIPTION
No need to add all netty when tinyradius only uses stuff from codec, buffer and transport (the later two is being used by codec so we can get away with flagging codec as the only dependency from netty)