### PR TITLE
Dev

### DIFF
--- a/src/main/java/org/tinyradius/core/attribute/AttributeHolder.java
+++ b/src/main/java/org/tinyradius/core/attribute/AttributeHolder.java
@@ -141,7 +141,7 @@ public interface AttributeHolder<T extends AttributeHolder<T>> {
      * @return RadiusAttribute object or null if there is no such attribute
      */
     default Optional<RadiusAttribute> getAttribute(String type) {
-        return filterAttributes(type).stream().findFirst();
+        return getAttributes(type).stream().findFirst();
     }
 
     /**
@@ -151,7 +151,7 @@ public interface AttributeHolder<T extends AttributeHolder<T>> {
      * @return RadiusAttribute object or null if there is no such attribute
      */
     default Optional<RadiusAttribute> getAttribute(int type) {
-        return filterAttributes(type).stream().findFirst();
+        return getAttributes(type).stream().findFirst();
     }
 
     /**
@@ -160,8 +160,8 @@ public interface AttributeHolder<T extends AttributeHolder<T>> {
      * @param type type of attributes to get
      * @return list of RadiusAttribute objects, or empty list
      */
-    default List<RadiusAttribute> filterAttributes(int type) {
-        return filterAttributes(a -> a.getType() == type);
+    default List<RadiusAttribute> getAttributes(int type) {
+        return getAttributes(a -> a.getType() == type);
     }
 
     /**
@@ -171,10 +171,10 @@ public interface AttributeHolder<T extends AttributeHolder<T>> {
      * @param name attribute type name
      * @return list of RadiusAttribute objects, or empty list
      */
-    default List<RadiusAttribute> filterAttributes(String name) {
+    default List<RadiusAttribute> getAttributes(String name) {
         final Optional<AttributeTemplate> type = getDictionary().getAttributeTemplate(name);
         if (type.isPresent())
-            return filterAttributes(type.get());
+            return getAttributes(type.get());
 
         throw new IllegalArgumentException("Unknown attribute type name'" + name + "'");
     }
@@ -185,7 +185,7 @@ public interface AttributeHolder<T extends AttributeHolder<T>> {
      * @param filter RadiusAttribute filter predicate
      * @return list of RadiusAttribute objects, or empty list
      */
-    default List<RadiusAttribute> filterAttributes(Predicate<RadiusAttribute> filter) {
+    default List<RadiusAttribute> getAttributes(Predicate<RadiusAttribute> filter) {
         return getAttributes().stream()
                 .filter(filter)
                 .collect(Collectors.toList());
@@ -198,9 +198,9 @@ public interface AttributeHolder<T extends AttributeHolder<T>> {
      * @param type attribute type name
      * @return list of RadiusAttribute objects, or empty list
      */
-    default List<RadiusAttribute> filterAttributes(AttributeTemplate type) {
+    default List<RadiusAttribute> getAttributes(AttributeTemplate type) {
         if (type.getVendorId() == getChildVendorId())
-            return filterAttributes(type.getType());
+            return getAttributes(type.getType());
 
         return Collections.emptyList();
     }
@@ -261,7 +261,7 @@ public interface AttributeHolder<T extends AttributeHolder<T>> {
      */
     default T removeAttribute(RadiusAttribute attribute) throws RadiusPacketException {
         return withAttributes(
-                filterAttributes(a -> !a.equals(attribute)));
+                getAttributes(a -> !a.equals(attribute)));
     }
 
     /**
@@ -273,7 +273,7 @@ public interface AttributeHolder<T extends AttributeHolder<T>> {
      */
     default T removeAttributes(int type) throws RadiusPacketException {
         return withAttributes(
-                filterAttributes(a -> a.getType() != type));
+                getAttributes(a -> a.getType() != type));
     }
 
     /**
@@ -285,7 +285,7 @@ public interface AttributeHolder<T extends AttributeHolder<T>> {
      * @throws RadiusPacketException packet validation exceptions
      */
     default T removeLastAttribute(int type) throws RadiusPacketException {
-        List<RadiusAttribute> attributes = filterAttributes(type);
+        List<RadiusAttribute> attributes = getAttributes(type);
         if (attributes.isEmpty())
             return withAttributes(getAttributes());
 

--- a/src/main/java/org/tinyradius/core/attribute/AttributeTemplate.java
+++ b/src/main/java/org/tinyradius/core/attribute/AttributeTemplate.java
@@ -15,6 +15,8 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 import static org.tinyradius.core.attribute.codec.AttributeCodecType.*;
+import static org.tinyradius.core.attribute.rfc.Rfc2865.USER_PASSWORD;
+import static org.tinyradius.core.attribute.rfc.Rfc2868.TUNNEL_PASSWORD;
 import static org.tinyradius.core.attribute.type.VendorSpecificAttribute.VENDOR_SPECIFIC;
 
 /**
@@ -261,21 +263,20 @@ public class AttributeTemplate {
     }
 
     private static boolean detectHasTag(int vendorId, int type, boolean hasTag) {
-        // Tunnel-Password
-        return (vendorId == -1 && type == 69) || hasTag;
+        return (vendorId == -1 && type == TUNNEL_PASSWORD) || hasTag;
     }
 
     private static AttributeCodecType detectAttributeCodec(int vendorId, int type, byte encryptFlag) {
-        if (vendorId == -1 && type == 2) // User-Password
+        if (vendorId == -1 && type == USER_PASSWORD)
             return RFC2865_USER_PASSWORD;
 
-        if (vendorId == -1 && type == 69) // Tunnel-Password
+        if (vendorId == -1 && type == TUNNEL_PASSWORD)
             return RFC2868_TUNNEL_PASSWORD;
 
         if (vendorId == 529 && type == 214) // Ascend-Send-Secret
-            return ASCENT_SEND_SECRET;
+            return ASCEND_SEND_SECRET;
 
-        return fromId(encryptFlag);
+        return fromEncryptFlagId(encryptFlag);
     }
 
     @Override

--- a/src/main/java/org/tinyradius/core/attribute/NestedAttributeHolder.java
+++ b/src/main/java/org/tinyradius/core/attribute/NestedAttributeHolder.java
@@ -25,9 +25,9 @@ public interface NestedAttributeHolder<T extends NestedAttributeHolder<T>> exten
      * @param type     attribute type code
      * @return list of RadiusAttribute objects, or empty list
      */
-    default List<RadiusAttribute> filterAttributes(int vendorId, int type) {
+    default List<RadiusAttribute> getAttributes(int vendorId, int type) {
         if (vendorId == getChildVendorId())
-            return filterAttributes(type);
+            return getAttributes(type);
 
         return getVendorAttributes(vendorId).stream()
                 .map(VendorSpecificAttribute::getAttributes)
@@ -37,8 +37,8 @@ public interface NestedAttributeHolder<T extends NestedAttributeHolder<T>> exten
     }
 
     @Override
-    default List<RadiusAttribute> filterAttributes(AttributeTemplate type) {
-        return filterAttributes(type.getVendorId(), type.getType());
+    default List<RadiusAttribute> getAttributes(AttributeTemplate type) {
+        return getAttributes(type.getVendorId(), type.getType());
     }
 
     /**
@@ -51,7 +51,7 @@ public interface NestedAttributeHolder<T extends NestedAttributeHolder<T>> exten
      * @return RadiusAttribute object or null if there is no such attribute
      */
     default Optional<RadiusAttribute> getAttribute(int vendorId, int type) {
-        return filterAttributes(vendorId, type).stream().findFirst();
+        return getAttributes(vendorId, type).stream().findFirst();
     }
 
     /**
@@ -111,7 +111,7 @@ public interface NestedAttributeHolder<T extends NestedAttributeHolder<T>> exten
                         return a;
 
                     final VendorSpecificAttribute vsa = (VendorSpecificAttribute) a;
-                    final List<RadiusAttribute> subAttributes = vsa.filterAttributes(sa -> !sa.equals(attribute));
+                    final List<RadiusAttribute> subAttributes = vsa.getAttributes(sa -> !sa.equals(attribute));
                     return subAttributes.isEmpty() ? null : vsa.withAttributes(subAttributes);
                 })
                 .filter(Objects::nonNull)
@@ -140,7 +140,7 @@ public interface NestedAttributeHolder<T extends NestedAttributeHolder<T>> exten
                         return a;
 
                     final VendorSpecificAttribute vsa = (VendorSpecificAttribute) a;
-                    final List<RadiusAttribute> subAttributes = vsa.filterAttributes(sa -> sa.getType() != type || sa.getVendorId() != vendorId);
+                    final List<RadiusAttribute> subAttributes = vsa.getAttributes(sa -> sa.getType() != type || sa.getVendorId() != vendorId);
                     return subAttributes.isEmpty() ? null : vsa.withAttributes(subAttributes);
                 })
                 .filter(Objects::nonNull)

--- a/src/main/java/org/tinyradius/core/attribute/codec/AttributeCodecType.java
+++ b/src/main/java/org/tinyradius/core/attribute/codec/AttributeCodecType.java
@@ -1,5 +1,7 @@
 package org.tinyradius.core.attribute.codec;
 
+import java.util.Arrays;
+
 /**
  * Attribute encryption methods as used in FreeRadius dictionary files
  */
@@ -10,7 +12,7 @@ public enum AttributeCodecType {
             (byte) 1, new UserPasswordCodec()),
     RFC2868_TUNNEL_PASSWORD(
             (byte) 2, new TunnelPasswordCodec()),
-    ASCENT_SEND_SECRET(
+    ASCEND_SEND_SECRET(
             (byte) 3, new AscendSendSecretCodec());
 
     private final byte id;
@@ -29,17 +31,10 @@ public enum AttributeCodecType {
         return codec;
     }
 
-    public static AttributeCodecType fromId(byte id) {
-        switch (id) {
-            case 1:
-                return RFC2865_USER_PASSWORD;
-            case 2:
-                return RFC2868_TUNNEL_PASSWORD;
-            case 3:
-                return ASCENT_SEND_SECRET;
-            case 0:
-            default:
-                return NO_ENCRYPT;
-        }
+    public static AttributeCodecType fromEncryptFlagId(byte id) {
+        return Arrays.stream(values())
+                .filter(t -> t.getId() == id)
+                .findFirst()
+                .orElse(NO_ENCRYPT);
     }
 }

--- a/src/main/java/org/tinyradius/core/attribute/rfc/Rfc2865.java
+++ b/src/main/java/org/tinyradius/core/attribute/rfc/Rfc2865.java
@@ -1,0 +1,49 @@
+package org.tinyradius.core.attribute.rfc;
+
+public class Rfc2865 {
+
+    private Rfc2865() {
+    }
+
+    public static final byte USER_NAME = 1;
+    public static final byte USER_PASSWORD = 2;
+    public static final byte CHAP_PASSWORD = 3;
+    public static final byte NAS_IP_ADDRESS = 4;
+    public static final byte NAS_PORT = 5;
+    public static final byte SERVICE_TYPE = 6;
+    public static final byte FRAMED_PROTOCOL = 7;
+    public static final byte FRAMED_IP_ADDRESS = 8;
+    public static final byte FRAMED_IP_NETMASK = 9;
+    public static final byte FRAMED_ROUTING = 10;
+    public static final byte FILTER_ID = 11;
+    public static final byte FRAMED_MTU = 12;
+    public static final byte FRAMED_COMPRESSION = 13;
+    public static final byte LOGIN_IP_HOST = 14;
+    public static final byte LOGIN_SERVICE = 15;
+    public static final byte LOGIN_TCP_PORT = 16;
+    public static final byte REPLY_MESSAGE = 18;
+    public static final byte CALLBACK_NUMBER = 19;
+    public static final byte CALLBACK_ID = 20;
+    public static final byte FRAMED_ROUTE = 22;
+    public static final byte FRAMED_IPX_NETWORK = 23;
+    public static final byte STATE = 24;
+    public static final byte CLASS = 25;
+    public static final byte VENDOR_SPECIFIC = 26;
+    public static final byte SESSION_TIMEOUT = 27;
+    public static final byte IDLE_TIMEOUT = 28;
+    public static final byte TERMINATION_ACTION = 29;
+    public static final byte CALLED_STATION_ID = 30;
+    public static final byte CALLING_STATION_ID = 31;
+    public static final byte NAS_IDENTIFIER = 32;
+    public static final byte PROXY_STATE = 33;
+    public static final byte LOGIN_LAT_SERVICE = 34;
+    public static final byte LOGIN_LAT_NODE = 35;
+    public static final byte LOGIN_LAT_GROUP = 36;
+    public static final byte FRAMED_APPLE_TALK_LINK = 37;
+    public static final byte FRAMED_APPLE_TALK_NETWORK = 38;
+    public static final byte FRAMED_APPLE_TALK_ZONE = 39;
+    public static final byte CHAP_CHALLENGE = 60;
+    public static final byte NAS_PORT_TYPE = 61;
+    public static final byte PORT_LIMIT = 62;
+    public static final byte LOGIN_LAT_PORT = 63;
+}

--- a/src/main/java/org/tinyradius/core/attribute/rfc/Rfc2866.java
+++ b/src/main/java/org/tinyradius/core/attribute/rfc/Rfc2866.java
@@ -1,0 +1,20 @@
+package org.tinyradius.core.attribute.rfc;
+
+public class Rfc2866 {
+
+    private Rfc2866() {
+    }
+
+    public static final byte ACCT_STATUS_TYPE = 40;
+    public static final byte ACCT_DELAY_TIME = 41;
+    public static final byte ACCT_INPUT_OCTETS = 42;
+    public static final byte ACCT_OUTPUT_OCTETS = 43;
+    public static final byte ACCT_SESSION_ID = 44;
+    public static final byte ACCT_AUTHENTIC = 45;
+    public static final byte ACCT_SESSION_TIME = 46;
+    public static final byte ACCT_INPUT_PACKETS = 47;
+    public static final byte ACCT_OUTPUT_PACKETS = 48;
+    public static final byte ACCT_TERMINATE_CAUSE = 49;
+    public static final byte ACCT_MULTI_SESSION_ID = 50;
+    public static final byte ACCT_LINK_COUNT = 51;
+}

--- a/src/main/java/org/tinyradius/core/attribute/rfc/Rfc2868.java
+++ b/src/main/java/org/tinyradius/core/attribute/rfc/Rfc2868.java
@@ -5,14 +5,14 @@ public class Rfc2868 {
     private Rfc2868() {
     }
 
-    private static final byte TUNNEL_TYPE = 64;
-    private static final byte TUNNEL_MEDIUM_TYPE = 65;
-    private static final byte TUNNEL_CLIENT_ENDPOINT = 66;
-    private static final byte TUNNEL_SERVER_ENDPOINT = 67;
-    private static final byte TUNNEL_PASSWORD = 69;
-    private static final byte TUNNEL_PRIVATE_GROUP_ID = 81;
-    private static final byte TUNNEL_ASSIGNMENT_ID = 82;
-    private static final byte TUNNEL_PREFERENCE = 83;
-    private static final byte TUNNEL_CLIENT_AUTH_ID = 90;
-    private static final byte TUNNEL_SERVER_AUTH_ID = 91;
+    public static final byte TUNNEL_TYPE = 64;
+    public static final byte TUNNEL_MEDIUM_TYPE = 65;
+    public static final byte TUNNEL_CLIENT_ENDPOINT = 66;
+    public static final byte TUNNEL_SERVER_ENDPOINT = 67;
+    public static final byte TUNNEL_PASSWORD = 69;
+    public static final byte TUNNEL_PRIVATE_GROUP_ID = 81;
+    public static final byte TUNNEL_ASSIGNMENT_ID = 82;
+    public static final byte TUNNEL_PREFERENCE = 83;
+    public static final byte TUNNEL_CLIENT_AUTH_ID = 90;
+    public static final byte TUNNEL_SERVER_AUTH_ID = 91;
 }

--- a/src/main/java/org/tinyradius/core/attribute/rfc/Rfc2868.java
+++ b/src/main/java/org/tinyradius/core/attribute/rfc/Rfc2868.java
@@ -1,0 +1,18 @@
+package org.tinyradius.core.attribute.rfc;
+
+public class Rfc2868 {
+
+    private Rfc2868() {
+    }
+
+    private static final byte TUNNEL_TYPE = 64;
+    private static final byte TUNNEL_MEDIUM_TYPE = 65;
+    private static final byte TUNNEL_CLIENT_ENDPOINT = 66;
+    private static final byte TUNNEL_SERVER_ENDPOINT = 67;
+    private static final byte TUNNEL_PASSWORD = 69;
+    private static final byte TUNNEL_PRIVATE_GROUP_ID = 81;
+    private static final byte TUNNEL_ASSIGNMENT_ID = 82;
+    private static final byte TUNNEL_PREFERENCE = 83;
+    private static final byte TUNNEL_CLIENT_AUTH_ID = 90;
+    private static final byte TUNNEL_SERVER_AUTH_ID = 91;
+}

--- a/src/main/java/org/tinyradius/core/attribute/rfc/Rfc2869.java
+++ b/src/main/java/org/tinyradius/core/attribute/rfc/Rfc2869.java
@@ -16,7 +16,7 @@ public class Rfc2869 {
     public static final byte CONFIGURATION_TOKEN = 78;
     public static final byte EAP_MESSAGE = 79;
     public static final byte MESSAGE_AUTHENTICATOR = 80;
-    public static final byte ARAP_CHALLENGE_RESPONse = 84;
+    public static final byte ARAP_CHALLENGE_RESPONSE = 84;
     public static final byte ACCT_INTERIM_INTERVAL = 85;
     public static final byte NAS_PORT_ID = 87;
     public static final byte FRAMED_POOL = 88;

--- a/src/main/java/org/tinyradius/core/attribute/rfc/Rfc2869.java
+++ b/src/main/java/org/tinyradius/core/attribute/rfc/Rfc2869.java
@@ -1,0 +1,23 @@
+package org.tinyradius.core.attribute.rfc;
+
+public class Rfc2869 {
+
+    private Rfc2869() {
+    }
+
+    public static final byte ARAP_PASSWORD = 70;
+    public static final byte ARAP_FEATURES = 71;
+    public static final byte ARAP_ZONE_ACCESS = 72;
+    public static final byte ARAP_SECURITY = 73;
+    public static final byte ARAP_SECURITY_DATA = 74;
+    public static final byte PASSWORD_RETRY = 75;
+    public static final byte PROMPT = 76;
+    public static final byte CONNECT_INFO = 77;
+    public static final byte CONFIGURATION_TOKEN = 78;
+    public static final byte EAP_MESSAGE = 79;
+    public static final byte MESSAGE_AUTHENTICATOR = 80;
+    public static final byte ARAP_CHALLENGE_RESPONse = 84;
+    public static final byte ACCT_INTERIM_INTERVAL = 85;
+    public static final byte NAS_PORT_ID = 87;
+    public static final byte FRAMED_POOL = 88;
+}

--- a/src/main/java/org/tinyradius/core/attribute/rfc/Rfc3162.java
+++ b/src/main/java/org/tinyradius/core/attribute/rfc/Rfc3162.java
@@ -1,0 +1,14 @@
+package org.tinyradius.core.attribute.rfc;
+
+public class Rfc3162 {
+
+    private Rfc3162() {
+    }
+
+    public static final byte NAS_IPV6_ADDRESS = 95;
+    public static final byte FRAMED_INTERFACE_ID = 96;
+    public static final byte FRAMED_IPV6_PREFIX = 97;
+    public static final byte LOGIN_IPV6_HOST = 98;
+    public static final byte FRAMED_IPV6_ROUTE = 99;
+    public static final byte FRAMED_IPV6_POOL = 100;
+}

--- a/src/main/java/org/tinyradius/core/attribute/type/OctetsAttribute.java
+++ b/src/main/java/org/tinyradius/core/attribute/type/OctetsAttribute.java
@@ -95,7 +95,7 @@ public class OctetsAttribute implements RadiusAttribute {
         final String tag = getTag()
                 .map(t -> ":" + t)
                 .orElse("");
-        return getAttributeName() + tag + " = " + getValueString();
+        return getAttributeName() + tag + "=" + getValueString();
     }
 
     @Override

--- a/src/main/java/org/tinyradius/core/packet/BaseRadiusPacket.java
+++ b/src/main/java/org/tinyradius/core/packet/BaseRadiusPacket.java
@@ -9,7 +9,9 @@ import org.tinyradius.core.attribute.AttributeTemplate;
 import org.tinyradius.core.attribute.type.RadiusAttribute;
 import org.tinyradius.core.dictionary.Dictionary;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Base Radius Packet implementation without support for authenticators or encoding
@@ -93,7 +95,8 @@ public abstract class BaseRadiusPacket<T extends RadiusPacket<T>> implements Rad
 
     /**
      * Naive with(), does not recalculate packet lengths in header.
-     * @param header Radius packet header
+     *
+     * @param header     Radius packet header
      * @param attributes Radius packet attributes
      * @return RadiusPacket with the specified headers and attributes
      * @throws RadiusPacketException packet validation exceptions
@@ -137,9 +140,14 @@ public abstract class BaseRadiusPacket<T extends RadiusPacket<T>> implements Rad
                 .append(", ID ").append(getId())
                 .append(", len ").append(getLength());
 
-        for (RadiusAttribute attr : getAttributes()) {
-            s.append("\n").append(attr.toString());
+        if (!getAttributes().isEmpty()) {
+            s.append(", attributes={");
+            for (RadiusAttribute attr : getAttributes()) {
+                s.append("\n").append(attr.toString());
+            }
+            s.append("\n}");
         }
+
         return s.toString();
     }
 

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
@@ -65,14 +65,12 @@ public abstract class AccessRequest extends GenericRequest implements MessageAut
                 .filter(AUTH_ATTRS::contains)
                 .collect(toSet());
 
-        if (detectedAuth.isEmpty()) {
-            // will occur a lot as PAP/CHAP are generally created by RadiusRequest.create().withPapPassword()
+        // will occur a lot as PAP/CHAP are generally created by RadiusRequest.create().withPapPassword()
+        if (detectedAuth.isEmpty())
             return AccessRequestNoAuth::new;
-        }
 
         if (detectedAuth.size() > 1) {
-            // bad packet
-            logger.warn("Identified multiple auth mechanisms, inferring NoAuth");
+            logger.warn("Identified multiple auth mechanisms, inferring NoAuth"); // bad packet
             return AccessRequestNoAuth::new;
         }
 

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
@@ -10,10 +10,7 @@ import org.tinyradius.core.packet.RadiusPacket;
 import org.tinyradius.core.packet.util.MessageAuthSupport;
 
 import java.security.SecureRandom;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.stream.Collectors.toSet;
 import static org.tinyradius.core.packet.PacketType.ACCESS_REQUEST;
@@ -26,6 +23,7 @@ public abstract class AccessRequest extends GenericRequest implements MessageAut
     protected static final Logger logger = LogManager.getLogger();
     protected static final SecureRandom RANDOM = new SecureRandom();
 
+    protected static final int USER_NAME = 1;
     protected static final int USER_PASSWORD = 2;
     protected static final int CHAP_PASSWORD = 3;
     protected static final int EAP_MESSAGE = 79;
@@ -107,6 +105,16 @@ public abstract class AccessRequest extends GenericRequest implements MessageAut
     }
 
     /**
+     * Retrieves the username
+     *
+     * @return username as String
+     */
+    public Optional<String> getUsername() {
+        return getAttribute(-1, USER_NAME)
+                .map(RadiusAttribute::getValueString);
+    }
+
+    /**
      * Set CHAP-Password attribute with provided password and initializes
      * CHAP-Challenge with random bytes.
      * <p>
@@ -144,7 +152,7 @@ public abstract class AccessRequest extends GenericRequest implements MessageAut
      * @return instance without USER_PASSWORD, CHAP_PASSWORD, ARAP_PASSWORD, EAP_MESSAGE attributes
      */
     private AccessRequest withoutAuths() throws RadiusPacketException {
-        return withAttributes(filterAttributes(a -> !(a.getVendorId() == -1 && AUTH_ATTRS.contains(a.getType()))));
+        return withAttributes(getAttributes(a -> !(a.getVendorId() == -1 && AUTH_ATTRS.contains(a.getType()))));
     }
 
     /**

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
@@ -67,7 +67,6 @@ public abstract class AccessRequest extends GenericRequest implements MessageAut
 
         if (detectedAuth.isEmpty()) {
             // will occur a lot as PAP/CHAP are generally created by RadiusRequest.create().withPapPassword()
-            logger.debug("No auth attributes found, inferring NoAuth");
             return AccessRequestNoAuth::new;
         }
 

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
@@ -4,6 +4,8 @@ import io.netty.buffer.ByteBuf;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.tinyradius.core.RadiusPacketException;
+import org.tinyradius.core.attribute.rfc.Rfc2865;
+import org.tinyradius.core.attribute.rfc.Rfc2869;
 import org.tinyradius.core.attribute.type.RadiusAttribute;
 import org.tinyradius.core.dictionary.Dictionary;
 import org.tinyradius.core.packet.RadiusPacket;
@@ -23,11 +25,11 @@ public abstract class AccessRequest extends GenericRequest implements MessageAut
     protected static final Logger logger = LogManager.getLogger();
     protected static final SecureRandom RANDOM = new SecureRandom();
 
-    protected static final int USER_NAME = 1;
-    protected static final int USER_PASSWORD = 2;
-    protected static final int CHAP_PASSWORD = 3;
-    protected static final int EAP_MESSAGE = 79;
-    protected static final int ARAP_PASSWORD = 70;
+    protected static final int USER_NAME = Rfc2865.USER_NAME;
+    protected static final int USER_PASSWORD = Rfc2865.USER_PASSWORD;
+    protected static final int CHAP_PASSWORD = Rfc2865.CHAP_PASSWORD;
+    protected static final int EAP_MESSAGE = Rfc2869.EAP_MESSAGE;
+    protected static final int ARAP_PASSWORD = Rfc2869.ARAP_PASSWORD;
 
     private static final Set<Integer> AUTH_ATTRS = new HashSet<>(
             Arrays.asList(USER_PASSWORD, CHAP_PASSWORD, ARAP_PASSWORD, EAP_MESSAGE));

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequestArap.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequestArap.java
@@ -30,7 +30,7 @@ public class AccessRequestArap extends AccessRequest {
     }
 
     private void validateArapAttributes() throws RadiusPacketException {
-        final int count = filterAttributes(ARAP_PASSWORD).size();
+        final int count = getAttributes(ARAP_PASSWORD).size();
         if (count != 1)
             throw new RadiusPacketException("AccessRequest (ARAP) should have exactly one ARAP-Password attribute, has " + count);
     }

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequestChap.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequestChap.java
@@ -120,7 +120,7 @@ public class AccessRequestChap extends AccessRequest {
     }
 
     private void validateChapAttributes() throws RadiusPacketException {
-        final int count = filterAttributes(CHAP_PASSWORD).size();
+        final int count = getAttributes(CHAP_PASSWORD).size();
         if (count != 1)
             throw new RadiusPacketException("AccessRequest (CHAP) should have exactly one CHAP-Password attribute, has " + count);
         // CHAP-Challenge can use Request Authenticator instead of attribute

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequestEap.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequestEap.java
@@ -27,7 +27,7 @@ public class AccessRequestEap extends AccessRequest {
     public RadiusRequest decodeRequest(String sharedSecret) throws RadiusPacketException {
         validateEapAttributes();
 
-        final List<RadiusAttribute> messageAuthAttr = filterAttributes(MESSAGE_AUTHENTICATOR);
+        final List<RadiusAttribute> messageAuthAttr = getAttributes(MESSAGE_AUTHENTICATOR);
         if (messageAuthAttr.size() != 1)
             throw new RadiusPacketException("AccessRequest (EAP) should have exactly one Message-Authenticator attribute, has " + messageAuthAttr.size());
 
@@ -35,7 +35,7 @@ public class AccessRequestEap extends AccessRequest {
     }
 
     private void validateEapAttributes() throws RadiusPacketException {
-        final List<RadiusAttribute> eapMessageAttr = filterAttributes(EAP_MESSAGE);
+        final List<RadiusAttribute> eapMessageAttr = getAttributes(EAP_MESSAGE);
         if (eapMessageAttr.isEmpty())
             throw new RadiusPacketException("AccessRequest (EAP) must have at least one EAP-Message attribute");
     }

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequestPap.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequestPap.java
@@ -43,8 +43,7 @@ public class AccessRequestPap extends AccessRequest {
      */
     public Optional<String> getPassword() {
         return getAttribute(-1, USER_PASSWORD)
-                .map(RadiusAttribute::getValue)
-                .map(v -> new String(v, UTF_8));
+                .map(RadiusAttribute::getValueString);
     }
 
     @Override
@@ -60,7 +59,7 @@ public class AccessRequestPap extends AccessRequest {
     }
 
     private void checkUserPassword() throws RadiusPacketException {
-        final int count = filterAttributes(USER_PASSWORD).size();
+        final int count = getAttributes(USER_PASSWORD).size();
         if (count != 1)
             throw new RadiusPacketException("AccessRequest (PAP) should have exactly one User-Password attribute, has " + count);
     }

--- a/src/main/java/org/tinyradius/core/packet/util/MessageAuthSupport.java
+++ b/src/main/java/org/tinyradius/core/packet/util/MessageAuthSupport.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.tinyradius.core.RadiusPacketException;
 import org.tinyradius.core.attribute.AttributeTemplate;
+import org.tinyradius.core.attribute.rfc.Rfc2869;
 import org.tinyradius.core.attribute.type.RadiusAttribute;
 import org.tinyradius.core.packet.RadiusPacket;
 
@@ -26,7 +27,7 @@ import java.util.Objects;
 public interface MessageAuthSupport<T extends RadiusPacket<T>> extends RadiusPacket<T> {
 
     Logger msgAuthLogger = LogManager.getLogger();
-    int MESSAGE_AUTHENTICATOR = 80;
+    int MESSAGE_AUTHENTICATOR = Rfc2869.MESSAGE_AUTHENTICATOR;
 
     static byte[] calcMessageAuthInput(RadiusPacket<?> packet, byte[] requestAuth) {
         final ByteBuf buf = Unpooled.buffer()

--- a/src/main/java/org/tinyradius/core/packet/util/MessageAuthSupport.java
+++ b/src/main/java/org/tinyradius/core/packet/util/MessageAuthSupport.java
@@ -60,7 +60,7 @@ public interface MessageAuthSupport<T extends RadiusPacket<T>> extends RadiusPac
     }
 
     default void verifyMessageAuth(String sharedSecret, byte[] requestAuth) throws RadiusPacketException {
-        final List<RadiusAttribute> msgAuthAttr = filterAttributes(MESSAGE_AUTHENTICATOR);
+        final List<RadiusAttribute> msgAuthAttr = getAttributes(MESSAGE_AUTHENTICATOR);
 
         if (msgAuthAttr.isEmpty())
             return;
@@ -111,7 +111,7 @@ public interface MessageAuthSupport<T extends RadiusPacket<T>> extends RadiusPac
         final ByteBuffer buffer = ByteBuffer.allocate(16);
         final RadiusAttribute attribute = getDictionary().createAttribute(-1, MESSAGE_AUTHENTICATOR, (byte) 0, buffer.array());
 
-        final List<RadiusAttribute> attributes = filterAttributes(a -> a.getType() != MESSAGE_AUTHENTICATOR);
+        final List<RadiusAttribute> attributes = getAttributes(a -> a.getType() != MESSAGE_AUTHENTICATOR);
         attributes.add(attribute);
 
         // manually build attribute list instead of using convenience methods to avoid new packet creation

--- a/src/main/java/org/tinyradius/io/client/handler/PromiseAdapter.java
+++ b/src/main/java/org/tinyradius/io/client/handler/PromiseAdapter.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.tinyradius.core.attribute.rfc.Rfc2865.PROXY_STATE;
 
 /**
  * ClientHandler that matches requests/response by appending Proxy-State attribute to
@@ -26,8 +27,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class PromiseAdapter extends MessageToMessageCodec<RadiusResponse, PendingRequestCtx> {
 
     private static final Logger logger = LogManager.getLogger();
-
-    public static final byte PROXY_STATE = 33;
 
     private final Map<String, Request> requests;
 

--- a/src/main/java/org/tinyradius/io/client/handler/PromiseAdapter.java
+++ b/src/main/java/org/tinyradius/io/client/handler/PromiseAdapter.java
@@ -65,7 +65,7 @@ public class PromiseAdapter extends MessageToMessageCodec<RadiusResponse, Pendin
     protected void decode(ChannelHandlerContext ctx, RadiusResponse msg, List<Object> out) {
 
         // retrieve my Proxy-State attribute (the last)
-        final List<RadiusAttribute> proxyStates = msg.filterAttributes(PROXY_STATE);
+        final List<RadiusAttribute> proxyStates = msg.getAttributes(PROXY_STATE);
         if (proxyStates.isEmpty()) {
             logger.warn("Ignoring response - no Proxy-State attribute");
             return;

--- a/src/main/java/org/tinyradius/io/client/handler/PromiseAdapter.java
+++ b/src/main/java/org/tinyradius/io/client/handler/PromiseAdapter.java
@@ -6,6 +6,7 @@ import io.netty.util.concurrent.Promise;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.tinyradius.core.RadiusPacketException;
+import org.tinyradius.core.attribute.rfc.Rfc2865;
 import org.tinyradius.core.attribute.type.RadiusAttribute;
 import org.tinyradius.core.packet.request.RadiusRequest;
 import org.tinyradius.core.packet.response.RadiusResponse;
@@ -17,7 +18,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.tinyradius.core.attribute.rfc.Rfc2865.PROXY_STATE;
 
 /**
  * ClientHandler that matches requests/response by appending Proxy-State attribute to
@@ -28,11 +28,16 @@ public class PromiseAdapter extends MessageToMessageCodec<RadiusResponse, Pendin
 
     private static final Logger logger = LogManager.getLogger();
 
+    private static final byte PROXY_STATE = Rfc2865.PROXY_STATE;
+
     private final Map<String, Request> requests;
 
     public PromiseAdapter() {
-        // todo inject map impl
-        requests = new ConcurrentHashMap<>();
+        this(new ConcurrentHashMap<>());
+    }
+
+    public PromiseAdapter(Map<String, Request> requestMap) {
+        this.requests = requestMap;
     }
 
     @Override
@@ -98,7 +103,7 @@ public class PromiseAdapter extends MessageToMessageCodec<RadiusResponse, Pendin
         }
     }
 
-    private static class Request {
+    public static class Request {
 
         private final String secret;
         private final byte[] auth;

--- a/src/test/java/org/tinyradius/core/attribute/AttributeTemplateTest.java
+++ b/src/test/java/org/tinyradius/core/attribute/AttributeTemplateTest.java
@@ -17,14 +17,13 @@ import java.util.Arrays;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.tinyradius.core.attribute.codec.AttributeCodecType.*;
+import static org.tinyradius.core.attribute.rfc.Rfc2865.USER_PASSWORD;
+import static org.tinyradius.core.attribute.rfc.Rfc2868.TUNNEL_PASSWORD;
 
 class AttributeTemplateTest {
 
     private static final SecureRandom random = new SecureRandom();
     private static final Dictionary dictionary = DefaultDictionary.INSTANCE;
-
-    private static final int TUNNEL_PASSWORD = 69;
-    private static final int USER_PASSWORD = 2;
 
     /**
      * User-Password / Tunnel-Password / Ascent-Send-Secret should ignore encrypt/tag flags
@@ -67,7 +66,7 @@ class AttributeTemplateTest {
         final EncodedAttribute tunnelPasswordEncoded = (EncodedAttribute) tunnelPassword.createEncoded(customDict, (byte) 1, new byte[4]);
         assertTrue(tunnelPasswordEncoded.getTag().isPresent());
 
-        assertEquals(ASCENT_SEND_SECRET, ascendSend.getCodecType());
+        assertEquals(ASCEND_SEND_SECRET, ascendSend.getCodecType());
         final IntegerAttribute ascendSendDecoded = (IntegerAttribute) ascendSend.create(customDict, (byte) 1, new byte[4]);
         assertFalse(ascendSendDecoded.getTag().isPresent());
         final EncodedAttribute ascendSendEncoded = (EncodedAttribute) ascendSend.createEncoded(customDict, (byte) 1, new byte[4]);

--- a/src/test/java/org/tinyradius/core/attribute/type/IntegerAttributeTest.java
+++ b/src/test/java/org/tinyradius/core/attribute/type/IntegerAttributeTest.java
@@ -144,7 +144,7 @@ class IntegerAttributeTest {
         assertEquals(6, serviceType.toByteArray().length);
         assertArrayEquals(new byte[]{0, 0, 0, 3}, serviceType.getValue());
         assertEquals(IntegerAttribute.class, serviceType.getClass());
-        assertEquals("Service-Type = Callback-Login-User", serviceType.toString());
+        assertEquals("Service-Type=Callback-Login-User", serviceType.toString());
         assertEquals(3, serviceType.getValueInt());
         assertEquals("Callback-Login-User", serviceType.getValueString());
         assertFalse(serviceType.getTag().isPresent());
@@ -177,7 +177,7 @@ class IntegerAttributeTest {
         assertEquals(6, vlan.toByteArray().length);
         assertArrayEquals(new byte[]{0, 0, 2}, vlan.getValue());
         assertEquals(IntegerAttribute.class, vlan.getClass());
-        assertEquals("Tunnel-Type:123 = L2F", vlan.toString());
+        assertEquals("Tunnel-Type:123=L2F", vlan.toString());
         assertEquals(2, vlan.getValueInt());
         assertEquals("L2F", vlan.getValueString());
         assertEquals((byte) 123, vlan.getTag().get());

--- a/src/test/java/org/tinyradius/core/attribute/type/OctetsAttributeTest.java
+++ b/src/test/java/org/tinyradius/core/attribute/type/OctetsAttributeTest.java
@@ -55,13 +55,13 @@ class OctetsAttributeTest {
     @Test
     void testFlatten() {
         final OctetsAttribute attribute = OCTETS.create(dictionary, -1, 3, (byte) 0, "FFFF0000"); // CHAP-Password
-        assertEquals("[CHAP-Password = 0xFFFF0000]", attribute.flatten().toString());
+        assertEquals("[CHAP-Password=0xFFFF0000]", attribute.flatten().toString());
     }
 
     @Test
     void testToString() {
         final OctetsAttribute attribute = OCTETS.create(dictionary, -1, 3, (byte) 0, "FFFF0000"); // CHAP-Password
-        assertEquals("CHAP-Password = 0xFFFF0000", attribute.toString());
+        assertEquals("CHAP-Password=0xFFFF0000", attribute.toString());
     }
 
     @Test
@@ -110,7 +110,7 @@ class OctetsAttributeTest {
         assertFalse(attribute.isEncoded());
         assertEquals(tag, attribute.getTag().get());
         assertArrayEquals(value, attribute.getValue());
-        assertEquals("Tunnel-Password:123 = 0x00002710", attribute.toString());
+        assertEquals("Tunnel-Password:123=0x00002710", attribute.toString());
 
         // encode
         final EncodedAttribute encode = (EncodedAttribute) attribute.encode(requestAuth, secret);

--- a/src/test/java/org/tinyradius/core/attribute/type/VendorSpecificAttributeTest.java
+++ b/src/test/java/org/tinyradius/core/attribute/type/VendorSpecificAttributeTest.java
@@ -385,7 +385,7 @@ class VendorSpecificAttributeTest {
                 dictionary.createAttribute("WISPr-Location-Name", "myLocationName")
         ));
 
-        assertEquals("[WISPr-Location-ID = myLocationId, WISPr-Location-Name = myLocationName]",
+        assertEquals("[WISPr-Location-ID=myLocationId, WISPr-Location-Name=myLocationName]",
                 vsa.flatten().toString());
     }
 
@@ -397,8 +397,8 @@ class VendorSpecificAttributeTest {
         ));
 
         assertEquals("Vendor-Specific: Vendor ID 14122 (WISPr)\n" +
-                     "  WISPr-Location-ID = myLocationId\n" +
-                     "  WISPr-Location-Name = myLocationName", vsa.toString());
+                "  WISPr-Location-ID=myLocationId\n" +
+                "  WISPr-Location-Name=myLocationName", vsa.toString());
     }
 
     @Test

--- a/src/test/java/org/tinyradius/core/dictionary/parser/DictionaryParserTest.java
+++ b/src/test/java/org/tinyradius/core/dictionary/parser/DictionaryParserTest.java
@@ -62,7 +62,7 @@ class DictionaryParserTest {
 
         final AttributeTemplate encryptTagAttribute = dictionary.getAttributeTemplate("WISPr-Bandwidth-Max-Down").get();
         assertTrue(encryptTagAttribute.isTagged());
-        assertEquals(ASCENT_SEND_SECRET, encryptTagAttribute.getCodecType());
+        assertEquals(ASCEND_SEND_SECRET, encryptTagAttribute.getCodecType());
     }
 
     @Test
@@ -88,7 +88,7 @@ class DictionaryParserTest {
 
         final AttributeTemplate encryptTagAttribute = dictionary.getAttributeTemplate("Ascend-FR-08-Mode").get();
         assertTrue(encryptTagAttribute.isTagged());
-        assertEquals(ASCENT_SEND_SECRET, encryptTagAttribute.getCodecType());
+        assertEquals(ASCEND_SEND_SECRET, encryptTagAttribute.getCodecType());
     }
 
     @Test
@@ -113,7 +113,7 @@ class DictionaryParserTest {
 
         final AttributeTemplate encryptTagAttribute = dictionary.getAttributeTemplate("PKM-Auth-Key").get();
         assertTrue(encryptTagAttribute.isTagged());
-        assertEquals(ASCENT_SEND_SECRET, encryptTagAttribute.getCodecType());
+        assertEquals(ASCEND_SEND_SECRET, encryptTagAttribute.getCodecType());
     }
 
     @Test

--- a/src/test/java/org/tinyradius/core/packet/BaseRadiusPacketTest.java
+++ b/src/test/java/org/tinyradius/core/packet/BaseRadiusPacketTest.java
@@ -66,13 +66,13 @@ class BaseRadiusPacketTest {
         assertArrayEquals(new String[]{"fe80:0:0:0:0:0:0:0/64", "fe80:0:0:0:0:0:0:0/128"},
                 ipV6Attributes.stream().map(RadiusAttribute::getValueString).toArray());
 
-        assertEquals("Access-Request, ID 1, len 96\n" +
+        assertEquals("Access-Request, ID 1, len 96, attributes={\n" +
                 "Vendor-Specific: Vendor ID 14122 (WISPr)\n" +
-                "  WISPr-Location-ID = myLocationId\n" +
-                "Framed-IP-Address = 0.18.214.135\n" +
-                "Framed-IPv6-Address = fe80:0:0:0:0:0:0:0\n" +
-                "Framed-IPv6-Prefix = fe80:0:0:0:0:0:0:0/64\n" +
-                "Framed-IPv6-Prefix = fe80:0:0:0:0:0:0:0/128", packet.toString());
+                "  WISPr-Location-ID=myLocationId\n" +
+                "Framed-IP-Address=0.18.214.135\n" +
+                "Framed-IPv6-Address=fe80:0:0:0:0:0:0:0\n" +
+                "Framed-IPv6-Prefix=fe80:0:0:0:0:0:0:0/64\n" +
+                "Framed-IPv6-Prefix=fe80:0:0:0:0:0:0:0/128\n}", packet.toString());
     }
 
     @Test
@@ -163,11 +163,11 @@ class BaseRadiusPacketTest {
 
         final List<RadiusAttribute> attributes = radiusPacket.getFlattenedAttributes();
 
-        assertEquals("Service-Type = 999", attributes.get(0).toString());
-        assertEquals("Filter-Id = abc", attributes.get(1).toString());
-        assertEquals("Reply-Message = foobar", attributes.get(2).toString());
-        assertEquals("WISPr-Logoff-URL = 111", attributes.get(3).toString());
-        assertEquals("WISPr-Logoff-URL = 222", attributes.get(4).toString());
+        assertEquals("Service-Type=999", attributes.get(0).toString());
+        assertEquals("Filter-Id=abc", attributes.get(1).toString());
+        assertEquals("Reply-Message=foobar", attributes.get(2).toString());
+        assertEquals("WISPr-Logoff-URL=111", attributes.get(3).toString());
+        assertEquals("WISPr-Logoff-URL=222", attributes.get(4).toString());
         // getAttributes only gets the last subAttribute of VendorSpecificAttribute
 
         assertEquals(5, attributes.size());

--- a/src/test/java/org/tinyradius/core/packet/BaseRadiusPacketTest.java
+++ b/src/test/java/org/tinyradius/core/packet/BaseRadiusPacketTest.java
@@ -53,7 +53,7 @@ class BaseRadiusPacketTest {
         assertEquals("myLocationId", wisprLocations.get(0).getValueString());
 
         assertEquals("myLocationId", packet.getAttribute(14122, 1).get().getValueString());
-        final List<RadiusAttribute> wisprLocations2 = packet.filterAttributes(14122, 1);
+        final List<RadiusAttribute> wisprLocations2 = packet.getAttributes(14122, 1);
         assertEquals(1, wisprLocations2.size());
         assertEquals("myLocationId", wisprLocations2.get(0).getValueString());
 
@@ -62,7 +62,7 @@ class BaseRadiusPacketTest {
         assertEquals("fe80:0:0:0:0:0:0:0", packet.getAttribute(168).get().getValueString());
         assertEquals("fe80:0:0:0:0:0:0:0", packet.getAttribute("Framed-IPv6-Address").get().getValueString());
 
-        final List<RadiusAttribute> ipV6Attributes = packet.filterAttributes(97);
+        final List<RadiusAttribute> ipV6Attributes = packet.getAttributes(97);
         assertArrayEquals(new String[]{"fe80:0:0:0:0:0:0:0/64", "fe80:0:0:0:0:0:0:0/128"},
                 ipV6Attributes.stream().map(RadiusAttribute::getValueString).toArray());
 
@@ -126,20 +126,20 @@ class BaseRadiusPacketTest {
         // remove once
         final StubPacket rp2 = rp.removeLastAttribute(6);
 
-        List<RadiusAttribute> rp2Attributes = rp2.filterAttributes(6);
+        List<RadiusAttribute> rp2Attributes = rp2.getAttributes(6);
         assertEquals(1, rp2Attributes.size());
         assertEquals("Login-User", rp2Attributes.get(0).getValueString());
 
         // remove again
         final StubPacket rp3 = rp2.removeLastAttribute(6);
 
-        List<RadiusAttribute> rp3Attributes = rp3.filterAttributes(6);
+        List<RadiusAttribute> rp3Attributes = rp3.getAttributes(6);
         assertEquals(0, rp3Attributes.size());
 
         // last remove should do nothing
         final StubPacket rp4 = rp3.removeLastAttribute(6);
 
-        List<RadiusAttribute> rp4Attributes = rp4.filterAttributes(6);
+        List<RadiusAttribute> rp4Attributes = rp4.getAttributes(6);
         assertEquals(0, rp4Attributes.size());
 
         assertEquals(3, rp.getAttributes().size());

--- a/src/test/java/org/tinyradius/core/packet/request/AccessRequestChapTest.java
+++ b/src/test/java/org/tinyradius/core/packet/request/AccessRequestChapTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.tinyradius.core.attribute.rfc.Rfc2865.USER_NAME;
 import static org.tinyradius.core.packet.PacketType.ACCESS_REQUEST;
 import static org.tinyradius.core.packet.request.AccessRequest.CHAP_PASSWORD;
 
@@ -20,8 +21,6 @@ class AccessRequestChapTest {
 
     private static final SecureRandom random = new SecureRandom();
     private static final Dictionary dictionary = DefaultDictionary.INSTANCE;
-
-    private static final byte USER_NAME = 1;
 
     @Test
     void encodeDecode() throws RadiusPacketException {

--- a/src/test/java/org/tinyradius/core/packet/request/RadiusRequestTest.java
+++ b/src/test/java/org/tinyradius/core/packet/request/RadiusRequestTest.java
@@ -134,7 +134,7 @@ class RadiusRequestTest {
         assertEquals(maxSizeRequest.getId(), result.getId());
         assertArrayEquals(maxSizeRequest.toBytes(), result.toBytes());
 
-        assertEquals(maxSizeRequest.filterAttributes(33).size(), result.filterAttributes(33).size());
+        assertEquals(maxSizeRequest.getAttributes(33).size(), result.getAttributes(33).size());
 
         // reconvert to check if bytes match
         assertArrayEquals(datagram.content().copy().array(), new DatagramPacket(result.toByteBuf(), new InetSocketAddress(0)).content().copy().array());

--- a/src/test/java/org/tinyradius/core/packet/request/RadiusRequestTest.java
+++ b/src/test/java/org/tinyradius/core/packet/request/RadiusRequestTest.java
@@ -13,12 +13,12 @@ import java.security.SecureRandom;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.tinyradius.core.attribute.rfc.Rfc2865.USER_NAME;
 import static org.tinyradius.core.packet.PacketType.*;
 
 class RadiusRequestTest {
 
     private static final int HEADER_LENGTH = 20;
-    private static final byte USER_NAME = 1;
 
     private final SecureRandom random = new SecureRandom();
     private final Dictionary dictionary = DefaultDictionary.INSTANCE;

--- a/src/test/java/org/tinyradius/e2e/EndToEndTest.java
+++ b/src/test/java/org/tinyradius/e2e/EndToEndTest.java
@@ -6,6 +6,7 @@ import org.tinyradius.core.dictionary.DefaultDictionary;
 import org.tinyradius.core.dictionary.Dictionary;
 import org.tinyradius.core.packet.request.AccessRequest;
 import org.tinyradius.core.packet.request.RadiusRequest;
+import org.tinyradius.core.packet.response.RadiusResponse;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -39,8 +40,6 @@ class EndToEndTest {
         RadiusRequest ar = ((AccessRequest) RadiusRequest.create(dictionary, ACCESS_REQUEST, (byte) 1, null, List.of()))
                 .withPapPassword(pw)
                 .addAttribute("User-Name", username)
-                .addAttribute("NAS-Identifier", "this.is.my.nas-identifier.de")
-                .addAttribute("NAS-IP-Address", "192.168.0.100")
                 .addAttribute("Service-Type", "Login-User");
 
 
@@ -51,7 +50,9 @@ class EndToEndTest {
                 .addAttribute("NAS-Identifier", "this.is.my.nas-identifier.de")
                 .addAttribute("NAS-Port", "0");
 
-        harness.testClient("localhost", PROXY_ACCESS_PORT, PROXY_ACCT_PORT, PROXY_SECRET, List.of(ar, acc));
+        final List<RadiusResponse> responses = harness.testClient("localhost", PROXY_ACCESS_PORT, PROXY_ACCT_PORT, PROXY_SECRET, List.of(ar, acc));
+        System.out.println("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+        System.out.println(responses);
 
         // TODO assert responses
 

--- a/src/test/java/org/tinyradius/e2e/Harness.java
+++ b/src/test/java/org/tinyradius/e2e/Harness.java
@@ -31,6 +31,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.Map;
 
 import static org.tinyradius.core.packet.PacketType.ACCESS_REQUEST;
 
@@ -75,7 +76,7 @@ public class Harness {
      * @param originSecret shared secret used by origin server
      * @return Closeable handler to trigger origin server shutdown
      */
-    public Closeable startOrigin(int originAccessPort, int originAcctPort, String originSecret) {
+    public Closeable startOrigin(int originAccessPort, int originAcctPort, String originSecret, Map<String, String> credentials) {
         EventLoopGroup eventLoopGroup = new NioEventLoopGroup(4);
         Bootstrap bootstrap = new Bootstrap().channel(NioDatagramChannel.class).group(eventLoopGroup);
 
@@ -84,7 +85,7 @@ public class Harness {
         BasicCachingHandler cachingHandlerAuth = new BasicCachingHandler(timer, 5000);
         BasicCachingHandler cachingHandlerAcct = new BasicCachingHandler(timer, 5000);
 
-        SimpleAccessHandler simpleAccessHandler = new SimpleAccessHandler();
+        SimpleAccessHandler simpleAccessHandler = new SimpleAccessHandler(credentials);
         SimpleAccountingHandler simpleAccountingHandler = new SimpleAccountingHandler();
 
         RadiusServer server = new RadiusServer(bootstrap,

--- a/src/test/java/org/tinyradius/e2e/handler/SimpleAccessHandler.java
+++ b/src/test/java/org/tinyradius/e2e/handler/SimpleAccessHandler.java
@@ -11,9 +11,9 @@ import org.tinyradius.io.server.handler.RequestHandler;
 
 import java.util.Map;
 
+import static org.tinyradius.core.attribute.rfc.Rfc2865.PROXY_STATE;
 import static org.tinyradius.core.packet.PacketType.ACCESS_ACCEPT;
 import static org.tinyradius.core.packet.PacketType.ACCESS_REJECT;
-import static org.tinyradius.io.client.handler.PromiseAdapter.PROXY_STATE;
 
 public class SimpleAccessHandler extends RequestHandler {
 

--- a/src/test/java/org/tinyradius/e2e/handler/SimpleAccountingHandler.java
+++ b/src/test/java/org/tinyradius/e2e/handler/SimpleAccountingHandler.java
@@ -8,8 +8,8 @@ import org.tinyradius.core.packet.response.RadiusResponse;
 import org.tinyradius.io.server.RequestCtx;
 import org.tinyradius.io.server.handler.RequestHandler;
 
+import static org.tinyradius.core.attribute.rfc.Rfc2865.PROXY_STATE;
 import static org.tinyradius.core.packet.PacketType.ACCOUNTING_RESPONSE;
-import static org.tinyradius.io.client.handler.PromiseAdapter.PROXY_STATE;
 
 public class SimpleAccountingHandler extends RequestHandler {
 

--- a/src/test/java/org/tinyradius/e2e/handler/SimpleAccountingHandler.java
+++ b/src/test/java/org/tinyradius/e2e/handler/SimpleAccountingHandler.java
@@ -22,7 +22,7 @@ public class SimpleAccountingHandler extends RequestHandler {
     protected void channelRead0(ChannelHandlerContext ctx, RequestCtx msg) throws RadiusPacketException {
         final RadiusRequest request = msg.getRequest();
         final RadiusResponse answer = RadiusResponse.create(
-                request.getDictionary(), ACCOUNTING_RESPONSE, request.getId(), null, request.filterAttributes(PROXY_STATE));
+                request.getDictionary(), ACCOUNTING_RESPONSE, request.getId(), null, request.getAttributes(PROXY_STATE));
 
         ctx.writeAndFlush(msg.withResponse(answer));
     }

--- a/src/test/java/org/tinyradius/io/client/handler/PromiseAdapterTest.java
+++ b/src/test/java/org/tinyradius/io/client/handler/PromiseAdapterTest.java
@@ -80,7 +80,7 @@ class PromiseAdapterTest {
         assertEquals(1, attributes1.size());
         assertEquals(2, attributes2.size());
 
-        final List<RadiusAttribute> attributes = processedPacket2.filterAttributes(PROXY_STATE);
+        final List<RadiusAttribute> attributes = processedPacket2.getAttributes(PROXY_STATE);
         assertEquals(requestId1, UUID.fromString(new String(attributes.get(0).getValue(), UTF_8)));
         assertNotEquals(requestId1, UUID.fromString(new String(attributes.get(1).getValue(), UTF_8)));
     }

--- a/src/test/java/org/tinyradius/io/client/handler/PromiseAdapterTest.java
+++ b/src/test/java/org/tinyradius/io/client/handler/PromiseAdapterTest.java
@@ -28,8 +28,8 @@ import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.tinyradius.core.attribute.rfc.Rfc2865.PROXY_STATE;
 import static org.tinyradius.core.packet.PacketType.*;
-import static org.tinyradius.io.client.handler.PromiseAdapter.PROXY_STATE;
 
 @ExtendWith(MockitoExtension.class)
 class PromiseAdapterTest {


### PR DESCRIPTION
- e2e tests
- add commonly used attributes type IDs as constants
- rename filterAttributes() to getAttributes() for consistency - convenience methods for AccessRequest username 