### PR TITLE
Refactor BlacklistHandler into two classes for clarity and better extendability

### DIFF
--- a/src/main/java/org/tinyradius/io/client/handler/BlacklistHandler.java
+++ b/src/main/java/org/tinyradius/io/client/handler/BlacklistHandler.java
@@ -9,12 +9,7 @@ import org.tinyradius.io.client.PendingRequestCtx;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.time.Clock;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * ChannelOutboundHandler that adds support for blacklists after multiple failures.
@@ -27,17 +22,14 @@ public class BlacklistHandler extends ChannelOutboundHandlerAdapter {
 
     private static final Logger logger = LogManager.getLogger();
 
-    private final long blacklistTtlMs;
-    private final int failCountThreshold;
-    private final Clock clock;
+    private final BlacklistManager blacklistManager;
 
-    private final Map<SocketAddress, AtomicInteger> failCounts = new ConcurrentHashMap<>();
-    private final Map<SocketAddress, Long> blacklist = new ConcurrentHashMap<>();
+    public BlacklistHandler(BlacklistManager blacklistManager) {
+        this.blacklistManager = blacklistManager;
+    }
 
     public BlacklistHandler(long blacklistTtlMs, int failCountThreshold, Clock clock) {
-        this.blacklistTtlMs = blacklistTtlMs;
-        this.failCountThreshold = failCountThreshold;
-        this.clock = clock;
+        this(new DefaultBlacklistManager(blacklistTtlMs, failCountThreshold, clock));
     }
 
     public BlacklistHandler(long blacklistTtlMs, int failCountThreshold) {
@@ -50,57 +42,22 @@ public class BlacklistHandler extends ChannelOutboundHandlerAdapter {
             final PendingRequestCtx request = (PendingRequestCtx) msg;
             final InetSocketAddress address = request.getEndpoint().getAddress();
 
-            if (isBlacklisted(address)) {
+            if (blacklistManager.isBlacklisted(address)) {
+                logger.debug("Endpoint blacklisted: {}", address);
                 request.getRequest().toByteBuf().release();
                 request.getResponse().tryFailure(new IOException("Client send failed - endpoint blacklisted: " + address));
                 return;
             }
 
             request.getResponse().addListener(f -> {
-                if (f.isSuccess())
-                    reset(address);
-                else
-                    logFailure(address, f.cause());
+                if (f.isSuccess()) {
+                    blacklistManager.reset(address);
+                } else {
+                    blacklistManager.logFailure(address, f.cause());
+                }
             });
         }
 
         ctx.write(msg, promise);
-    }
-
-    private boolean isBlacklisted(SocketAddress socketAddress) {
-        final Long blacklistExpiry = blacklist.get(socketAddress);
-
-        // not blacklisted
-        if (blacklistExpiry == null)
-            return false;
-
-        // blacklist active
-        if (clock.millis() < blacklistExpiry) {
-            logger.debug("Endpoint blacklisted while proxying packet to {}", socketAddress);
-            return true;
-        }
-
-        // blacklist expired
-        reset(socketAddress);
-        logger.info("Endpoint {} removed from blacklist (expired)", socketAddress);
-        return false;
-    }
-
-    private void logFailure(SocketAddress address, Throwable cause) {
-        if (cause instanceof TimeoutException) {
-            final int i = failCounts.computeIfAbsent(address, d -> new AtomicInteger()).incrementAndGet();
-
-            if (i >= failCountThreshold && blacklist.get(address) == null) {
-
-                // only set if isn't already blacklisted, to avoid delayed responses extending ttl
-                blacklist.put(address, clock.millis() + blacklistTtlMs);
-                logger.debug("Endpoint {} added to blacklist", address);
-            }
-        }
-    }
-
-    private void reset(SocketAddress socketAddress) {
-        blacklist.remove(socketAddress);
-        failCounts.remove(socketAddress);
     }
 }

--- a/src/main/java/org/tinyradius/io/client/handler/BlacklistManager.java
+++ b/src/main/java/org/tinyradius/io/client/handler/BlacklistManager.java
@@ -1,0 +1,9 @@
+package org.tinyradius.io.client.handler;
+
+import java.net.SocketAddress;
+
+public interface BlacklistManager {
+    boolean isBlacklisted(SocketAddress address);
+    void logFailure(SocketAddress address, Throwable cause);
+    void reset(SocketAddress address);
+}

--- a/src/main/java/org/tinyradius/io/client/handler/DefaultBlacklistManager.java
+++ b/src/main/java/org/tinyradius/io/client/handler/DefaultBlacklistManager.java
@@ -1,0 +1,65 @@
+package org.tinyradius.io.client.handler;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.SocketAddress;
+import java.time.Clock;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DefaultBlacklistManager implements BlacklistManager {
+    private static final Logger logger = LogManager.getLogger();
+    private final long blacklistTtlMs;
+    private final int failCountThreshold;
+    private final Clock clock;
+    private final Map<SocketAddress, AtomicInteger> failCounts = new ConcurrentHashMap<>();
+    private final Map<SocketAddress, Long> blacklist = new ConcurrentHashMap<>();
+
+    public DefaultBlacklistManager(long blacklistTtlMs, int failCountThreshold, Clock clock) {
+        this.blacklistTtlMs = blacklistTtlMs;
+        this.failCountThreshold = failCountThreshold;
+        this.clock = clock;
+    }
+
+    @Override
+    public boolean isBlacklisted(SocketAddress socketAddress) {
+        Long blacklistExpiry = blacklist.get(socketAddress);
+
+        // not blacklisted
+        if (blacklistExpiry == null)
+            return false;
+
+        // blacklist active
+        if (clock.millis() < blacklistExpiry) {
+            return true;
+        }
+
+        // blacklist expired
+        reset(socketAddress);
+        logger.info("Endpoint {} removed from blacklist (expired)", socketAddress);
+        return false;
+    }
+
+    @Override
+    public void logFailure(SocketAddress address, Throwable cause) {
+        if (cause instanceof TimeoutException) {
+            final int failCount = failCounts.computeIfAbsent(address, k -> new AtomicInteger()).incrementAndGet();
+
+            if (failCount >= failCountThreshold && blacklist.get(address) == null) {
+
+                // only set if isn't already blacklisted, to avoid delayed responses extending ttl
+                blacklist.put(address, clock.millis() + blacklistTtlMs);
+                logger.debug("Endpoint {} added to blacklist", address);
+            }
+        }
+    }
+
+    @Override
+    public void reset(SocketAddress socketAddress) {
+        blacklist.remove(socketAddress);
+        failCounts.remove(socketAddress);
+    }
+}


### PR DESCRIPTION
### Reason for this change

I want to be able to add some custom logic in for the blacklisting, like generating a warning if the a whole radius cluster is down, or if the whole cluster is down, reduce the TTL, so that it recovers faster.

This commit splits the original BlacklistHandler class into two separate classes to better adhere to the Single Responsibility Principle. Now, BlacklistHandler focuses solely on observing netty packet flow and raising exceptions when necessary, while a new class, DefaultBlacklistManager, handles the logic related to managing blacklisting, including fail counts and blacklist state.

This enables to customize the BlacklistHandler without having to deal with the packet-handling logic.