### PR TITLE
Refactoring buildheader

### DIFF
--- a/src/main/java/org/tinyradius/core/attribute/AttributeHolder.java
+++ b/src/main/java/org/tinyradius/core/attribute/AttributeHolder.java
@@ -216,7 +216,7 @@ public interface AttributeHolder<T extends AttributeHolder<T>> {
     T withAttributes(List<RadiusAttribute> attributes) throws RadiusPacketException;
 
     /**
-     * Adds a attribute to this attribute container.
+     * Adds an attribute to this attribute container.
      *
      * @param attribute attribute to add
      * @return object of same type with appended attribute

--- a/src/main/java/org/tinyradius/core/packet/BaseRadiusPacket.java
+++ b/src/main/java/org/tinyradius/core/packet/BaseRadiusPacket.java
@@ -23,7 +23,6 @@ import java.util.List;
 public abstract class BaseRadiusPacket<T extends RadiusPacket<T>> implements RadiusPacket<T> {
 
     private static final int HEADER_LENGTH = 20;
-    private static final int CHILD_VENDOR_ID = -1;
 
     private final Dictionary dictionary;
 
@@ -46,11 +45,6 @@ public abstract class BaseRadiusPacket<T extends RadiusPacket<T>> implements Rad
         if (length != declaredLength)
             throw new RadiusPacketException("Packet length mismatch, " +
                     "actual length (" + length + ")  does not match declared length (" + declaredLength + ")");
-    }
-
-    @Override
-    public int getChildVendorId() {
-        return CHILD_VENDOR_ID;
     }
 
     @Override

--- a/src/main/java/org/tinyradius/core/packet/BaseRadiusPacket.java
+++ b/src/main/java/org/tinyradius/core/packet/BaseRadiusPacket.java
@@ -63,20 +63,7 @@ public abstract class BaseRadiusPacket<T extends RadiusPacket<T>> implements Rad
         return withAuthAttributes(getAuthenticator(), attributes);
     }
 
-    public T withAuthAttributes(byte[] auth, List<RadiusAttribute> attributes) throws RadiusPacketException {
-        final ByteBuf newHeader = RadiusPacket.buildHeader(getType(), getId(), auth, attributes);
-        return with(newHeader, attributes);
-    }
-
-    /**
-     * Naive with(), does not recalculate packet lengths in header.
-     *
-     * @param header     Radius packet header
-     * @param attributes Radius packet attributes
-     * @return RadiusPacket with the specified headers and attributes
-     * @throws RadiusPacketException packet validation exceptions
-     */
-    protected abstract T with(ByteBuf header, List<RadiusAttribute> attributes) throws RadiusPacketException;
+    public abstract T withAuthAttributes(byte[] auth, List<RadiusAttribute> attributes) throws RadiusPacketException;
 
     /**
      * @param sharedSecret shared secret

--- a/src/main/java/org/tinyradius/core/packet/BaseRadiusPacket.java
+++ b/src/main/java/org/tinyradius/core/packet/BaseRadiusPacket.java
@@ -60,8 +60,7 @@ public abstract class BaseRadiusPacket<T extends RadiusPacket<T>> implements Rad
 
     @Override
     public T withAttributes(List<RadiusAttribute> attributes) throws RadiusPacketException {
-        final ByteBuf newHeader = RadiusPacket.buildHeader(getType(), getId(), getAuthenticator(), attributes);
-        return with(newHeader, attributes);
+        return withAuthAttributes(getAuthenticator(), attributes);
     }
 
     public T withAuthAttributes(byte[] auth, List<RadiusAttribute> attributes) throws RadiusPacketException {

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
@@ -6,7 +6,6 @@ import org.apache.logging.log4j.Logger;
 import org.tinyradius.core.RadiusPacketException;
 import org.tinyradius.core.attribute.type.RadiusAttribute;
 import org.tinyradius.core.dictionary.Dictionary;
-import org.tinyradius.core.packet.RadiusPacket;
 import org.tinyradius.core.packet.util.MessageAuthSupport;
 
 import java.security.SecureRandom;
@@ -164,7 +163,7 @@ public abstract class AccessRequest extends GenericRequest implements MessageAut
 
         final byte[] auth = genAuth(sharedSecret);
 
-        return withAuthAttributes(auth, encodeAttributes(auth, sharedSecret))
+        return ((AccessRequest) withAuthAttributes(auth, encodeAttributes(auth, sharedSecret)))
                 .encodeMessageAuth(sharedSecret, auth);
     }
 
@@ -182,11 +181,6 @@ public abstract class AccessRequest extends GenericRequest implements MessageAut
         return withAttributes(decodeAttributes(getAuthenticator(), sharedSecret));
     }
 
-    @Override
-    public AccessRequest withAuthAttributes(byte[] auth, List<RadiusAttribute> attributes) throws RadiusPacketException {
-        final ByteBuf header = RadiusPacket.buildHeader(getType(), getId(), auth, attributes);
-        return create(getDictionary(), header, attributes);
-    }
 
     public interface AccessRequestFactory {
         AccessRequest newInstance(Dictionary dictionary, ByteBuf header, List<RadiusAttribute> attributes) throws RadiusPacketException;

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
@@ -146,7 +146,7 @@ public abstract class AccessRequest extends GenericRequest implements MessageAut
      * @return instance without USER_PASSWORD, CHAP_PASSWORD, ARAP_PASSWORD, EAP_MESSAGE attributes
      */
     private AccessRequest withoutAuths() throws RadiusPacketException {
-        return withAttributes(getAttributes(a -> !(a.getVendorId() == -1 && AUTH_ATTRS.contains(a.getType()))));
+        return (AccessRequest) withAttributes(getAttributes(a -> !(a.getVendorId() == -1 && AUTH_ATTRS.contains(a.getType()))));
     }
 
     /**
@@ -180,11 +180,6 @@ public abstract class AccessRequest extends GenericRequest implements MessageAut
 
         verifyMessageAuth(sharedSecret, getAuthenticator());
         return withAttributes(decodeAttributes(getAuthenticator(), sharedSecret));
-    }
-
-    @Override
-    public AccessRequest withAttributes(List<RadiusAttribute> attributes) throws RadiusPacketException {
-        return withAuthAttributes(getAuthenticator(), attributes);
     }
 
     @Override

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequestChap.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequestChap.java
@@ -27,8 +27,7 @@ public class AccessRequestChap extends AccessRequest {
 
     static AccessRequest withPassword(AccessRequest request, String password) throws RadiusPacketException {
         final List<RadiusAttribute> attributes = withPasswordAttribute(request.getDictionary(), request.getAttributes(), password);
-        final ByteBuf header = RadiusPacket.buildHeader(request.getType(), request.getId(), request.getAuthenticator(), attributes);
-        return create(request.getDictionary(), header, attributes);
+        return (AccessRequest) request.withAttributes(attributes);
     }
 
     /**

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequestChap.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequestChap.java
@@ -10,9 +10,9 @@ import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toList;
 import static org.tinyradius.core.attribute.AttributeTypes.CHAP_CHALLENGE;
 import static org.tinyradius.core.attribute.AttributeTypes.CHAP_PASSWORD;
 
@@ -48,7 +48,7 @@ public class AccessRequestChap extends AccessRequest {
         final List<RadiusAttribute> newAttributes = attributes.stream()
                 .filter(a -> !(a.getVendorId() == -1 && a.getType() == CHAP_PASSWORD)
                         && !(a.getVendorId() == -1 && a.getType() == CHAP_CHALLENGE))
-                .collect(Collectors.toList());
+                .collect(toList());
 
         newAttributes.add(dictionary.createAttribute(-1, CHAP_CHALLENGE, challenge));
         newAttributes.add(dictionary.createAttribute(-1, CHAP_PASSWORD,

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequestPap.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequestPap.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import org.tinyradius.core.RadiusPacketException;
 import org.tinyradius.core.attribute.type.RadiusAttribute;
 import org.tinyradius.core.dictionary.Dictionary;
-import org.tinyradius.core.packet.RadiusPacket;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,8 +23,7 @@ public class AccessRequestPap extends AccessRequest {
 
     static AccessRequest withPassword(AccessRequest request, String password) throws RadiusPacketException {
         final List<RadiusAttribute> attributes = withPasswordAttribute(request.getDictionary(), request.getAttributes(), password);
-        final ByteBuf header = RadiusPacket.buildHeader(request.getType(), request.getId(), request.getAuthenticator(), attributes);
-        return create(request.getDictionary(), header, attributes);
+        return (AccessRequest) request.withAttributes(attributes);
     }
 
     private static List<RadiusAttribute> withPasswordAttribute(Dictionary dictionary, List<RadiusAttribute> attributes, String password) {

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequestPap.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequestPap.java
@@ -7,9 +7,9 @@ import org.tinyradius.core.dictionary.Dictionary;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toList;
 import static org.tinyradius.core.attribute.AttributeTypes.USER_PASSWORD;
 
 /**
@@ -29,7 +29,7 @@ public class AccessRequestPap extends AccessRequest {
     private static List<RadiusAttribute> withPasswordAttribute(Dictionary dictionary, List<RadiusAttribute> attributes, String password) {
         final List<RadiusAttribute> newAttributes = attributes.stream()
                 .filter(a -> a.getVendorId() != -1 || a.getType() != USER_PASSWORD)
-                .collect(Collectors.toList());
+                .collect(toList());
 
         newAttributes.add(dictionary.createAttribute(-1, USER_PASSWORD, password.getBytes(UTF_8)));
         return newAttributes;

--- a/src/main/java/org/tinyradius/core/packet/request/GenericRequest.java
+++ b/src/main/java/org/tinyradius/core/packet/request/GenericRequest.java
@@ -35,7 +35,7 @@ public class GenericRequest extends BaseRadiusPacket<RadiusRequest> implements R
     }
 
     @Override
-    protected RadiusRequest with(ByteBuf header, List<RadiusAttribute> attributes) throws RadiusPacketException {
-        return RadiusRequest.create(getDictionary(), header, attributes);
+    public RadiusRequest withAuthAttributes(byte[] auth, List<RadiusAttribute> attributes) throws RadiusPacketException {
+        return RadiusRequest.create(getDictionary(), getType(), getId(), auth, attributes);
     }
 }

--- a/src/main/java/org/tinyradius/core/packet/request/RadiusRequest.java
+++ b/src/main/java/org/tinyradius/core/packet/request/RadiusRequest.java
@@ -5,15 +5,14 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.socket.DatagramPacket;
 import org.tinyradius.core.RadiusPacketException;
 import org.tinyradius.core.attribute.AttributeHolder;
+import org.tinyradius.core.attribute.NestedAttributeHolder;
 import org.tinyradius.core.attribute.type.RadiusAttribute;
-import org.tinyradius.core.attribute.type.VendorSpecificAttribute;
 import org.tinyradius.core.dictionary.Dictionary;
 import org.tinyradius.core.packet.RadiusPacket;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
 import static org.tinyradius.core.packet.PacketType.ACCESS_REQUEST;
 import static org.tinyradius.core.packet.PacketType.ACCOUNTING_REQUEST;
 
@@ -43,10 +42,9 @@ public interface RadiusRequest extends RadiusPacket<RadiusRequest> {
      * @throws RadiusPacketException packet validation exceptions
      */
     static RadiusRequest create(Dictionary dictionary, byte type, byte id, byte[] authenticator, List<RadiusAttribute> attributes) throws RadiusPacketException {
-        // Wrap vendor specific attributes. Same as in NestedAttributesHolder
-        List<RadiusAttribute> wrappedAttributes = attributes.stream().map(attr -> 
-            attr.getVendorId() == -1 ? attr : new VendorSpecificAttribute(dictionary, attr.getVendorId(), Collections.singletonList(attr))
-            ).collect(Collectors.toList());
+        List<RadiusAttribute> wrappedAttributes = attributes.stream()
+                .map(NestedAttributeHolder::vsaAutowrap)
+                .collect(toList());
         final ByteBuf header = RadiusPacket.buildHeader(type, id, authenticator, wrappedAttributes);
         return create(dictionary, header, wrappedAttributes);
     }

--- a/src/main/java/org/tinyradius/core/packet/response/GenericResponse.java
+++ b/src/main/java/org/tinyradius/core/packet/response/GenericResponse.java
@@ -29,7 +29,7 @@ public class GenericResponse extends BaseRadiusPacket<RadiusResponse> implements
     }
 
     @Override
-    protected RadiusResponse with(ByteBuf header, List<RadiusAttribute> attributes) throws RadiusPacketException {
-        return RadiusResponse.create(getDictionary(), header, attributes);
+    public RadiusResponse withAuthAttributes(byte[] auth, List<RadiusAttribute> attributes) throws RadiusPacketException {
+        return RadiusResponse.create(getDictionary(), getType(), getId(), auth, attributes);
     }
 }

--- a/src/main/java/org/tinyradius/core/packet/response/RadiusResponse.java
+++ b/src/main/java/org/tinyradius/core/packet/response/RadiusResponse.java
@@ -33,8 +33,7 @@ public interface RadiusResponse extends RadiusPacket<RadiusResponse> {
 
     /**
      * Creates a RadiusPacket object. Depending on the passed type, an
-     * appropriate packet is created. Also sets the type, and the
-     * the packet id.
+     * appropriate packet is created. Also sets the type, and the packet id.
      *
      * @param dictionary    custom dictionary to use
      * @param type          packet type

--- a/src/test/java/org/tinyradius/core/attribute/type/VendorSpecificAttributeTest.java
+++ b/src/test/java/org/tinyradius/core/attribute/type/VendorSpecificAttributeTest.java
@@ -478,23 +478,4 @@ class VendorSpecificAttributeTest {
         final VendorSpecificAttribute decode1 = decoded.decode(requestAuth, secret);
         assertEquals(decode1, decoded);
     }
-
-    @Test
-    void addToRequest() throws RadiusPacketException{
-
-        // Create vendor specific attribute
-        final String vendorAttrName = "WISPr-Location-ID";
-        RadiusAttribute vsa = dictionary.createAttribute(vendorAttrName, "anything");
-
-        // This Works --- Create request with empty attribute list and add vsa later
-        RadiusRequest request1 = ((AccessRequest) RadiusRequest.create(dictionary, (byte)1, (byte) 1, null, List.of()));
-        request1 = request1.addAttribute(vsa);
-        // Check. Retrieve the just inserted attribute and check name
-        assertEquals(vendorAttrName, request1.getAttribute(vendorAttrName).get().getAttributeName());
-
-        // This fails --- Create request with vsa in attribute list at creation time
-        RadiusRequest request2 = ((AccessRequest) RadiusRequest.create(dictionary, (byte)1, (byte) 1, null, List.of(vsa)));
-        // Check. Try to retrieve the inserted attribute and verify its name
-        assertEquals(vendorAttrName, request2.getAttribute(vendorAttrName).get().getAttributeName());
-    }
 }

--- a/src/test/java/org/tinyradius/core/packet/BaseRadiusPacketTest.java
+++ b/src/test/java/org/tinyradius/core/packet/BaseRadiusPacketTest.java
@@ -1,6 +1,5 @@
 package org.tinyradius.core.packet;
 
-import io.netty.buffer.ByteBuf;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.tinyradius.core.RadiusPacketException;
@@ -224,7 +223,7 @@ class BaseRadiusPacketTest {
         }
 
         @Override
-        protected StubPacket with(ByteBuf header, List<RadiusAttribute> attributes) throws RadiusPacketException {
+        public StubPacket withAuthAttributes(byte[] auth, List<RadiusAttribute> attributes) throws RadiusPacketException {
             return new StubPacket(attributes);
         }
     }

--- a/src/test/java/org/tinyradius/core/packet/BaseRadiusPacketTest.java
+++ b/src/test/java/org/tinyradius/core/packet/BaseRadiusPacketTest.java
@@ -8,6 +8,7 @@ import org.tinyradius.core.attribute.type.RadiusAttribute;
 import org.tinyradius.core.attribute.type.VendorSpecificAttribute;
 import org.tinyradius.core.dictionary.Dictionary;
 import org.tinyradius.core.dictionary.parser.DictionaryParser;
+import org.tinyradius.core.packet.request.RadiusRequest;
 
 import java.io.IOException;
 import java.security.SecureRandom;
@@ -195,6 +196,21 @@ class BaseRadiusPacketTest {
                 Collections.singletonList(dictionary.createAttribute("User-Name", "a")));
         assertEquals(23, packet2.toByteBuf().readableBytes());
         assertEquals(23, packet2.toByteBuf().getShort(2));
+    }
+
+    @Test
+    void vsaAutoWrap() throws RadiusPacketException {
+        final String vendorAttrName = "WISPr-Location-ID";
+        RadiusAttribute vsa = dictionary.createAttribute(vendorAttrName, "anything");
+
+        // Create request with empty attribute list and add vsa later
+        RadiusRequest request1 = RadiusRequest.create(dictionary, (byte) 1, (byte) 1, null, List.of())
+                .addAttribute(vsa);
+        assertEquals(vendorAttrName, request1.getAttribute(vendorAttrName).get().getAttributeName());
+
+        // Create request with vsa in attribute list at creation time
+        RadiusRequest request2 = RadiusRequest.create(dictionary, (byte) 1, (byte) 1, null, List.of(vsa));
+        assertEquals(vendorAttrName, request2.getAttribute(vendorAttrName).get().getAttributeName());
     }
 
     private static class StubPacket extends BaseRadiusPacket<StubPacket> {

--- a/src/test/java/org/tinyradius/core/packet/util/MessageAuthSupportTest.java
+++ b/src/test/java/org/tinyradius/core/packet/util/MessageAuthSupportTest.java
@@ -1,6 +1,5 @@
 package org.tinyradius.core.packet.util;
 
-import io.netty.buffer.ByteBuf;
 import net.jradius.packet.RadiusFormat;
 import net.jradius.packet.RadiusPacket;
 import net.jradius.packet.attribute.Attr_UnknownAttribute;
@@ -91,8 +90,8 @@ class MessageAuthSupportTest {
         }
 
         @Override
-        protected TestPacket with(ByteBuf header, List<RadiusAttribute> attributes) throws RadiusPacketException {
-            return new TestPacket(header.getByte(0), header.getByte(1), header.slice(4, 16).copy().array(), attributes);
+        public TestPacket withAuthAttributes(byte[] auth, List<RadiusAttribute> attributes) throws RadiusPacketException {
+            return new TestPacket(getType(), getId(), getAuthenticator(), attributes);
         }
     }
 }

--- a/src/test/java/org/tinyradius/e2e/Harness.java
+++ b/src/test/java/org/tinyradius/e2e/Harness.java
@@ -30,8 +30,8 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
 import static org.tinyradius.core.packet.PacketType.ACCESS_REQUEST;
 
 @Log4j2
@@ -64,7 +64,7 @@ public class Harness {
                 log.info("Packet after it was sent\n{}\n", r);
                 log.info("Response\n{}\n", response);
                 return response;
-            }).collect(Collectors.toList());
+            }).collect(toList());
         }
     }
 


### PR DESCRIPTION
- Moved childVendorId from `BaseRadiusPacket` to `NestedAttributeHolder`
- Remove naive `BaseRadiusPacket.with()` method so header is built in `GenericResponse` or `GenericRequest`
- Reducing instances of ad-hoc header building
- Remove custom AccessRequest `withAttributes()` that provided minimal performance gain, deferring to the main `RadiusRequest.create()` and `RadiusResponse.create()` factory methods entrypoints