### PR TITLE
Refactor Packet Building

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-api:2.24.3'
     implementation 'io.netty:netty-codec-base:4.2.2.Final'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
+    implementation 'jakarta.annotation:jakarta.annotation-api:3.0.0'
 
     testImplementation 'org.apache.logging.log4j:log4j-core:2.24.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.1'

--- a/src/main/java/org/tinyradius/core/attribute/AttributeHolder.java
+++ b/src/main/java/org/tinyradius/core/attribute/AttributeHolder.java
@@ -146,6 +146,16 @@ public interface AttributeHolder<T extends AttributeHolder<T>> {
     }
 
     /**
+     * Convenience method to get single attribute filtered by given predicate
+     *
+     * @param filter RadiusAttribute filter predicate
+     * @return RadiusAttribute object or null if there is no such attribute
+     */
+    default Optional<RadiusAttribute> getAttribute(Predicate<RadiusAttribute> filter) {
+        return getAttributes(filter).stream().findFirst();
+    }
+
+    /**
      * Convenience method to get single attribute.
      *
      * @param type attribute type
@@ -179,7 +189,7 @@ public interface AttributeHolder<T extends AttributeHolder<T>> {
     }
 
     /**
-     * Returns attributes of the given type, filtered by given predicate
+     * Returns attributes filtered by given predicate
      *
      * @param filter RadiusAttribute filter predicate
      * @return list of RadiusAttribute objects, or empty list

--- a/src/main/java/org/tinyradius/core/attribute/AttributeTemplate.java
+++ b/src/main/java/org/tinyradius/core/attribute/AttributeTemplate.java
@@ -45,11 +45,11 @@ public class AttributeTemplate {
     private final String dataType;
 
     /**
-     * whether attribute supports Tag field as per RFC2868
+     * Whether attribute supports Tag field as per RFC2868
      */
     private final boolean tagged;
     /**
-     * one of AttributeCodecType enum, defaults to NO_ENCRYPT for none
+     * One of {@link AttributeCodecType} enum, defaults to NO_ENCRYPT for none
      */
     private final AttributeCodecType codecType;
 
@@ -207,7 +207,7 @@ public class AttributeTemplate {
      * @throws RadiusPacketException errors decoding attribute
      */
     public RadiusAttribute decode(RadiusAttribute attribute, byte[] requestAuth, String secret) throws RadiusPacketException {
-        if (!attribute.isEncoded())
+        if (attribute.isDecoded())
             return attribute;
 
         try {

--- a/src/main/java/org/tinyradius/core/attribute/type/EncodedAttribute.java
+++ b/src/main/java/org/tinyradius/core/attribute/type/EncodedAttribute.java
@@ -1,11 +1,12 @@
 package org.tinyradius.core.attribute.type;
 
+import io.netty.buffer.ByteBuf;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
-import lombok.experimental.Delegate;
 import org.tinyradius.core.RadiusPacketException;
 import org.tinyradius.core.attribute.AttributeTemplate;
 import org.tinyradius.core.attribute.codec.AttributeCodecType;
+import org.tinyradius.core.dictionary.Dictionary;
 
 import java.util.Optional;
 
@@ -18,7 +19,6 @@ import static org.tinyradius.core.attribute.codec.AttributeCodecType.NO_ENCRYPT;
 @EqualsAndHashCode
 public class EncodedAttribute implements RadiusAttribute {
 
-    @Delegate
     private final OctetsAttribute delegate;
 
     @Override
@@ -26,6 +26,36 @@ public class EncodedAttribute implements RadiusAttribute {
         final Optional<AttributeTemplate> template = getAttributeTemplate();
         return template.isPresent() ?
                 template.get().decode(this, requestAuth, secret) : delegate;
+    }
+
+    @Override
+    public int getVendorId() {
+        return delegate.getVendorId();
+    }
+
+    @Override
+    public Optional<Byte> getTag() {
+        return delegate.getTag();
+    }
+
+    @Override
+    public byte[] getValue() {
+        return delegate.getValue();
+    }
+
+    @Override
+    public String getValueString() {
+        return delegate.getValueString();
+    }
+
+    @Override
+    public Dictionary getDictionary() {
+        return delegate.getDictionary();
+    }
+
+    @Override
+    public ByteBuf getData() {
+        return delegate.getData();
     }
 
     @Override

--- a/src/main/java/org/tinyradius/core/attribute/type/RadiusAttribute.java
+++ b/src/main/java/org/tinyradius/core/attribute/type/RadiusAttribute.java
@@ -4,12 +4,15 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.tinyradius.core.RadiusPacketException;
 import org.tinyradius.core.attribute.AttributeTemplate;
+import org.tinyradius.core.attribute.codec.AttributeCodecType;
 import org.tinyradius.core.dictionary.Dictionary;
 import org.tinyradius.core.dictionary.Vendor;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import static org.tinyradius.core.attribute.codec.AttributeCodecType.NO_ENCRYPT;
 
 public interface RadiusAttribute {
 
@@ -133,6 +136,12 @@ public interface RadiusAttribute {
                 .orElse(false);
     }
 
+    default AttributeCodecType codecType() {
+        return getAttributeTemplate()
+                .map(AttributeTemplate::getCodecType)
+                .orElse(NO_ENCRYPT);
+    }
+
     default String getAttributeName() {
         return getAttributeTemplate()
                 .map(AttributeTemplate::getName)
@@ -184,5 +193,9 @@ public interface RadiusAttribute {
 
     default boolean isEncoded() {
         return false;
+    }
+
+    default boolean isDecoded() {
+        return !isEncoded();
     }
 }

--- a/src/main/java/org/tinyradius/core/packet/request/GenericRequest.java
+++ b/src/main/java/org/tinyradius/core/packet/request/GenericRequest.java
@@ -19,18 +19,21 @@ public class GenericRequest extends BaseRadiusPacket<RadiusRequest> implements R
      * @return new authenticator, must be idempotent
      */
     protected byte[] genAuth(String sharedSecret) {
-        return genHashedAuth(sharedSecret, new byte[16]);
+        return genHashedAuth(sharedSecret, null);
     }
 
     @Override
     public RadiusRequest encodeRequest(String sharedSecret) throws RadiusPacketException {
+        if (sharedSecret == null || sharedSecret.isEmpty())
+            throw new IllegalArgumentException("Shared secret cannot be null/empty");
+
         final byte[] auth = genAuth(sharedSecret);
         return withAuthAttributes(auth, encodeAttributes(auth, sharedSecret));
     }
 
     @Override
     public RadiusRequest decodeRequest(String sharedSecret) throws RadiusPacketException {
-        verifyPacketAuth(sharedSecret, new byte[16]);
+        verifyPacketAuth(sharedSecret, null);
         return withAttributes(decodeAttributes(getAuthenticator(), sharedSecret));
     }
 

--- a/src/main/java/org/tinyradius/core/packet/response/RadiusResponse.java
+++ b/src/main/java/org/tinyradius/core/packet/response/RadiusResponse.java
@@ -32,7 +32,7 @@ public interface RadiusResponse extends RadiusPacket<RadiusResponse> {
 
     /**
      * Creates a RadiusPacket object. Depending on the passed type, an
-     * appropriate packet is created. Also sets the type, and the packet id.
+     * appropriate packet is created. Also sets the type and the packet id.
      *
      * @param dictionary    custom dictionary to use
      * @param type          packet type

--- a/src/test/java/org/tinyradius/core/attribute/AttributeTemplateTest.java
+++ b/src/test/java/org/tinyradius/core/attribute/AttributeTemplateTest.java
@@ -102,7 +102,7 @@ class AttributeTemplateTest {
         final AttributeTemplate template = dictionary.getAttributeTemplate(USER_PASSWORD).get();
 
         assertArrayEquals(pw.getBytes(UTF_8), attribute.getValue());
-        assertFalse(attribute.isEncoded());
+        assertTrue(attribute.isDecoded());
 
         final RadiusAttribute encode1 = template.encode(attribute, requestAuth, secret);
         assertNotEquals(attribute, encode1);
@@ -117,13 +117,13 @@ class AttributeTemplateTest {
 
         final RadiusAttribute decode1 = template.decode(encode2, requestAuth, secret);
         assertEquals(attribute, decode1);
-        assertFalse(decode1.isEncoded());
+        assertTrue(decode1.isDecoded());
         assertArrayEquals(pw.getBytes(UTF_8), decode1.getValue());
 
         // idempotence check
         final RadiusAttribute decode2 = template.decode(decode1, requestAuth, secret);
         assertEquals(decode1, decode2);
-        assertFalse(decode2.isEncoded());
+        assertTrue(decode2.isDecoded());
         assertArrayEquals(pw.getBytes(UTF_8), decode2.getValue());
     }
 
@@ -139,7 +139,7 @@ class AttributeTemplateTest {
 
         assertEquals(tag, attribute.getTag().get());
         assertArrayEquals(pw.getBytes(UTF_8), attribute.getValue());
-        assertFalse(attribute.isEncoded());
+        assertTrue(attribute.isDecoded());
 
         final RadiusAttribute encode1 = template.encode(attribute, requestAuth, secret);
         assertNotEquals(attribute, encode1);
@@ -158,7 +158,7 @@ class AttributeTemplateTest {
 
         final RadiusAttribute decode1 = template.decode(encode2, requestAuth, secret);
         assertEquals(attribute, decode1);
-        assertFalse(decode1.isEncoded());
+        assertTrue(decode1.isDecoded());
         assertArrayEquals(pw.getBytes(UTF_8), decode1.getValue());
         assertEquals(tag, attribute.getTag().get());
         assertEquals(tag, attribute.toByteArray()[2]);
@@ -166,7 +166,7 @@ class AttributeTemplateTest {
         // idempotence check
         final RadiusAttribute decode2 = template.decode(decode1, requestAuth, secret);
         assertEquals(decode1, decode2);
-        assertFalse(decode2.isEncoded());
+        assertTrue(decode2.isDecoded());
         assertArrayEquals(pw.getBytes(UTF_8), decode2.getValue());
         assertEquals(tag, attribute.getTag().get());
         assertEquals(tag, attribute.toByteArray()[2]);

--- a/src/test/java/org/tinyradius/core/attribute/type/OctetsAttributeTest.java
+++ b/src/test/java/org/tinyradius/core/attribute/type/OctetsAttributeTest.java
@@ -75,7 +75,7 @@ class OctetsAttributeTest {
 
         // User-Password (we need something with encrypt)
         final OctetsAttribute attribute = FACTORY.create(dictionary, -1, USER_PASSWORD, (byte) 0, value);
-        assertFalse(attribute.isEncoded());
+        assertTrue(attribute.isDecoded());
         assertArrayEquals(value, attribute.getValue());
 
         // encode
@@ -89,7 +89,7 @@ class OctetsAttributeTest {
 
         // decode
         final OctetsAttribute decode = (OctetsAttribute) encode.decode(requestAuth, secret);
-        assertFalse(decode.isEncoded());
+        assertTrue(decode.isDecoded());
         assertArrayEquals(value, decode.getValue());
 
         // decode again
@@ -109,7 +109,7 @@ class OctetsAttributeTest {
 
         // Tunnel-Password (actually a StringAttribute, we need something with encrypt and tag )
         final OctetsAttribute attribute = FACTORY.create(testDictionary, -1, TUNNEL_PASSWORD, tag, value);
-        assertFalse(attribute.isEncoded());
+        assertTrue(attribute.isDecoded());
         assertEquals(tag, attribute.getTag().get());
         assertArrayEquals(value, attribute.getValue());
         assertEquals("Tunnel-Password:123=0x00002710", attribute.toString());
@@ -126,7 +126,7 @@ class OctetsAttributeTest {
 
         // decode
         final OctetsAttribute decode = (OctetsAttribute) encode.decode(requestAuth, secret);
-        assertFalse(decode.isEncoded());
+        assertTrue(decode.isDecoded());
         assertEquals(tag, decode.getTag().get());
         assertArrayEquals(value, decode.getValue());
 

--- a/src/test/java/org/tinyradius/core/packet/request/GenericRequestTest.java
+++ b/src/test/java/org/tinyradius/core/packet/request/GenericRequestTest.java
@@ -47,6 +47,9 @@ class GenericRequestTest {
         final RadiusRequest decoded2 = decoded.decodeRequest(sharedSecret);
         assertArrayEquals(decoded.toBytes(), decoded2.toBytes());
         assertEquals(username, decoded2.getAttribute("User-Name").get().getValueString());
+
+        // sanity check
+        assertArrayEquals(decoded.toBytes(), decoded.toByteBuffer().array());
     }
 
 

--- a/src/test/java/org/tinyradius/core/packet/util/MessageAuthSupportTest.java
+++ b/src/test/java/org/tinyradius/core/packet/util/MessageAuthSupportTest.java
@@ -45,8 +45,9 @@ class MessageAuthSupportTest {
         auth[0] = 1; // set auth to non-zeros
         final TestPacket testPacket = new TestPacket((byte) 1, (byte) 1, auth, Collections.emptyList());
 
-        final TestPacket encodedPacket = testPacket.encodeMessageAuth(secret, testPacket.getAuthenticator());
+        final TestPacket encodedPacket = testPacket.encodeMessageAuth(secret, null);
         encodedPacket.verifyMessageAuth(secret, testPacket.getAuthenticator());
+        encodedPacket.verifyMessageAuth(secret, null);
     }
 
     @Test

--- a/src/test/java/org/tinyradius/e2e/Harness.java
+++ b/src/test/java/org/tinyradius/e2e/Harness.java
@@ -8,6 +8,7 @@ import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
+import jakarta.annotation.Nonnull;
 import lombok.extern.log4j.Log4j2;
 import org.tinyradius.core.dictionary.DefaultDictionary;
 import org.tinyradius.core.dictionary.Dictionary;
@@ -26,7 +27,6 @@ import org.tinyradius.io.server.RadiusServer;
 import org.tinyradius.io.server.handler.BasicCachingHandler;
 import org.tinyradius.io.server.handler.ServerPacketCodec;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,4 +1,3 @@
 junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.mode.default=concurrent
-junit.jupiter.execution.parallel.config.strategy=fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism=4
+junit.jupiter.execution.parallel.config.strategy=dynamic


### PR DESCRIPTION
- Use jakarta.annotation-api
- More convenience methods
- Javadoc improvements
- Default requestAuth to empty array if null
- Simplify code path for encoding Access Requests