### PR TITLE
feature-adding-instrumentation-hooks to RadiusClient

### DIFF
--- a/doc/feature-adding-instrumentation-hooks.md
+++ b/doc/feature-adding-instrumentation-hooks.md
@@ -1,0 +1,49 @@
+# Feature: Attempts and timeout per request. Hooks for instrumentation of RadiusClient
+
+## Justification for the usefulness of the feature
+
+The `RadiusClient` object uses a `FixedTimeoutHandler` passed on creation which, as the name implies, uses the same values for `maxAttempts` and `timeoutMillis` for all requests. If using `Tinyradius-netty` as the core of a fully fledged radius server/proxy implementation, this poses a limitation, since it is usually desirable to have different values for those parameters for different upstream radius servers, while wanting to use the same `RadiusClient` instance.
+
+In addition, also for a fully fledged radius server/proxy implementation, it is important to have metrics for packets sent/received/timed-out. The current implementation of `RadiusClient` implements iternally a retry strategy, so that applications using it cannot record the number of times a packet was sent to an upstream radius server.
+
+## Rationale for the proposed implementation
+
+One possiblity would be to change the `TimeoutHandler.onTimeout` interface method to include the value of the timeout, but that would require a relatively major change. An approach that only adds new methods to the `RadiusClient` has been followed, ensuring backwards compatiblity, and not needing to rewrite any tests (only adding new ones).
+
+The modified `RadiusClient` has additional methods to:
+- Create internally and use another TimeoutHandler, instead of using the one specified at instantiation time (which is used as default), with parametrizable `maxAttempts` and `timeoutMillis`. 
+- Invoke Java functions ("hooks") when a packet is sent, when a packet is received and when a timeout is fired. Those "hooks" may be used by the external application to record radius client metrics. The hook has two parameters: the type (request in case of recording a sending or a timeout, response in case of recording a response), and the destination InetSocketAddress.
+
+## Implementation
+
+The signature of the enriched `communicate` method is as follows
+
+```java
+public Future<RadiusResponse> communicate(RadiusRequest packet, List<RadiusEndpoint> endpoints, int maxAttempts, int timeoutMillis,
+            BiConsumer<Byte, InetSocketAddress> preSendHook, BiConsumer<Byte, InetSocketAddress> timeoutHook, 
+            BiConsumer<Byte, InetSocketAddress> postReceiveHook)
+```
+
+Where `preSendHook` is invoked before sending the radius client request, `timeoutHook` is invoked when a timeout is fired, and `postReceiveHook` is invoked when a response is received, the `type` Byte parameter being the response type.
+
+And also analogous versions for `communicate` for a single Endpoint, such as
+
+```java
+public Future<RadiusResponse> communicate(RadiusRequest packet, List<RadiusEndpoint> endpoints, int maxAttempts, int timeoutMillis,
+            BiConsumer<Byte, InetSocketAddress> preSendHook, BiConsumer<Byte, InetSocketAddress> timeoutHook, 
+            BiConsumer<Byte, InetSocketAddress> postReceiveHook)
+```
+
+The implementation is pretty trivial, the only issue being the long list of parameters. The Hooks could be condensed in a specific Class, as done in the testing, but we have preferred to avoid defining unnecessary new types.
+
+## Note
+
+Happy to work on any other approach you may suggest to implement similar functionality.
+
+
+## One additional change
+
+Moved from `info` to `debug` 
+```java
+log.info("Found request for response identifier {}, proxyState requestId '{}'",...)
+```

--- a/src/main/java/org/tinyradius/io/client/RadiusClient.java
+++ b/src/main/java/org/tinyradius/io/client/RadiusClient.java
@@ -4,6 +4,7 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
+import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import lombok.extern.log4j.Log4j2;
@@ -11,20 +12,30 @@ import org.tinyradius.core.packet.request.RadiusRequest;
 import org.tinyradius.core.packet.response.RadiusResponse;
 import org.tinyradius.io.RadiusEndpoint;
 import org.tinyradius.io.RadiusLifecycle;
+import org.tinyradius.io.client.timeout.FixedTimeoutHandler;
 import org.tinyradius.io.client.timeout.TimeoutHandler;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 /**
  * A simple Radius client which binds to a specific socket, and can
  * then be used to send any number of packets to any endpoints through
  * that socket.
+ * 
+ * External functions to be invoke for each send try, timeout and response
+ * received may be optionally specified.
  */
 @Log4j2
 public class RadiusClient implements RadiusLifecycle {
 
+    // Will be used to create FixedTimeoutHandlers when not using the default
+    private final HashedWheelTimer timer;
+
+    // Used as default, if maxAttempts and timeoutMillis are not specified
     private final TimeoutHandler timeoutHandler;
     private final EventLoopGroup eventLoopGroup;
     private final ChannelFuture channelFuture;
@@ -38,59 +49,91 @@ public class RadiusClient implements RadiusLifecycle {
     public RadiusClient(Bootstrap bootstrap, SocketAddress listenAddress, TimeoutHandler timeoutHandler, ChannelHandler handler) {
         this.eventLoopGroup = bootstrap.config().group();
         this.timeoutHandler = timeoutHandler;
+        this.timer = new HashedWheelTimer();
         channelFuture = bootstrap.clone().handler(handler).bind(listenAddress);
     }
 
-    /**
-     * Sends packet to specified endpoints in turn until an endpoint succeeds or all fail.
-     *
-     * @param packet    packet to send
-     * @param endpoints endpoints to send packet to
-     * @return deferred response containing response packet or exception
-     */
-    public Future<RadiusResponse> communicate(RadiusRequest packet, List<RadiusEndpoint> endpoints) {
+    private Future<RadiusResponse> communicate(RadiusRequest packet, List<RadiusEndpoint> endpoints, TimeoutHandler perRequestTimeoutHandler,
+            BiConsumer<Byte, InetSocketAddress> preSendHook, BiConsumer<Byte, InetSocketAddress> timeoutHook, 
+            BiConsumer<Byte, InetSocketAddress> postReceiveHook) {
         if (endpoints.isEmpty())
             return eventLoopGroup.next().newFailedFuture(new IOException("Client send failed - no valid endpoints"));
 
         final Promise<RadiusResponse> promise = eventLoopGroup.next().newPromise();
-        communicateRecursive(packet, endpoints, 0, promise, null);
+        communicateRecursive(packet, endpoints, 0, promise, null, perRequestTimeoutHandler, preSendHook, timeoutHook, postReceiveHook);
 
         return promise;
     }
 
+    /**
+     * Sends packet to specified endpoints in turn until an endpoint succeeds or all fail.
+     * @param packet    packet to send
+     * @param endpoints endpoints to send packet to
+     * @param maxAttempts max attemtps per endpoint
+     * @param timeoutMillis timeout in milliseconds per request
+     * @param preSendHook function to invoke before sending the radius request. 
+     * Parameters are the type of request and InetSocket address of the remote
+     * @param timeoutHook function to invoke when a timeout expires. Parameters
+     * are the type of the request and the InetSocketAddress of the remote.
+     * @param postReceiveHook function to invoke when a responsne is received.
+     * Parameters are the type of the response and the InetSocketAddress of the remote.
+     * @return
+     */
+    public Future<RadiusResponse> communicate(RadiusRequest packet, List<RadiusEndpoint> endpoints, int maxAttempts, int timeoutMillis,
+                                              BiConsumer<Byte, InetSocketAddress> preSendHook, BiConsumer<Byte, InetSocketAddress> timeoutHook, 
+                                              BiConsumer<Byte, InetSocketAddress> postReceiveHook){
+        return communicate(packet, endpoints, new FixedTimeoutHandler(timer, maxAttempts, timeoutMillis), preSendHook, timeoutHook, postReceiveHook);
+    }
+
+    /**
+     * Sends packet to specified endpoints in turn until an endpoint succeeds or all fail.
+     * @param packet    packet to send
+     * @param endpoints endpoints to send packet to
+     * @return
+     */
+    public Future<RadiusResponse> communicate(RadiusRequest packet, List<RadiusEndpoint> endpoints){
+        return communicate(packet, endpoints, timeoutHandler, null, null, null);
+    }
+
     private void communicateRecursive(RadiusRequest packet, List<RadiusEndpoint> endpoints, int endpointIndex,
-                                      Promise<RadiusResponse> promise, Throwable lastException) {
+                                      Promise<RadiusResponse> promise, Throwable lastException,  TimeoutHandler perRequestTimeoutHandler,
+                                      BiConsumer<Byte, InetSocketAddress> preSendHook, BiConsumer<Byte, InetSocketAddress> timeoutHook, 
+                                      BiConsumer<Byte, InetSocketAddress> postReceiveHook) {
+
         if (endpointIndex >= endpoints.size()) {
             promise.tryFailure(new IOException("Client send failed - all endpoints failed", lastException));
             return;
         }
 
-        communicate(packet, endpoints.get(endpointIndex)).addListener((Future<RadiusResponse> f) -> {
+        communicate(packet, endpoints.get(endpointIndex), perRequestTimeoutHandler, preSendHook, timeoutHook, postReceiveHook).addListener((Future<RadiusResponse> f) -> {
             if (f.isSuccess())
                 promise.trySuccess(f.getNow());
             else
-                communicateRecursive(packet, endpoints, endpointIndex + 1, promise, f.cause());
+                communicateRecursive(packet, endpoints, endpointIndex + 1, promise, f.cause(), perRequestTimeoutHandler, preSendHook, timeoutHook, postReceiveHook);
         });
     }
 
-    /**
-     * Sends packet to specified endpoint.
-     *
-     * @param packet   packet to send
-     * @param endpoint endpoint to send packet to
-     * @return deferred response containing response packet or exception
-     */
-    public Future<RadiusResponse> communicate(RadiusRequest packet, RadiusEndpoint endpoint) {
+
+    private Future<RadiusResponse> communicate(RadiusRequest packet, RadiusEndpoint endpoint, TimeoutHandler perRequestTimeoutHandler, 
+                BiConsumer<Byte, InetSocketAddress> preSendHook, BiConsumer<Byte, InetSocketAddress> timeoutHook, 
+                BiConsumer<Byte, InetSocketAddress> postReceiveHook) {
+
         final Promise<RadiusResponse> promise = eventLoopGroup.next().<RadiusResponse>newPromise().addListener(f -> {
-            if (f.isSuccess())
-                log.info("Response received, packet: {}", f.getNow());
-            else
+            if (f.isSuccess()){
+                log.debug("Response received, packet: {}", f.getNow());
+                // Report response received to hook
+                if(postReceiveHook != null) postReceiveHook.accept(((RadiusResponse)f.getNow()).getType(), endpoint.getAddress());
+            }
+            else{
                 log.warn(f.cause().getMessage());
+                // Report final timeout to hook
+                if(timeoutHook != null) timeoutHook.accept(packet.getType(), endpoint.getAddress());
+            }
         });
 
         channelFuture.addListener(s -> {
             if (s.isSuccess())
-                send(new PendingRequestCtx(packet, endpoint, promise), 1);
+                send(new PendingRequestCtx(packet, endpoint, promise), 1, perRequestTimeoutHandler, preSendHook, timeoutHook);
             else
                 promise.tryFailure(s.cause());
         });
@@ -98,10 +141,50 @@ public class RadiusClient implements RadiusLifecycle {
         return promise;
     }
 
-    private void send(PendingRequestCtx ctx, int attempt) {
-        log.info("Attempt {}, sending packet to {}", attempt, ctx.getEndpoint().getAddress());
+    /**
+     * Sends packet to specified endpoint.
+     *
+     * @param packet   packet to send
+     * @param endpoint endpoint to send packet to
+     * @param maxAttempts max attemtps per endpoint
+     * @param timeoutMillis timeout in milliseconds per request
+     * @param preSendHook function to invoke before sending the radius request. 
+     * Parameters are the type of request and InetSocket address of the remote
+     * @param timeoutHook function to invoke when a timeout expires. Parameters
+     * are the type of the request and the InetSocketAddress of the remote.
+     * @param postReceiveHook function to invoke when a responsne is received.ctx
+     * Parameters are the type of the response and the InetSocketAddress of the remote.
+     * @return deferred response containing response packet or exception
+     */
+    public Future<RadiusResponse> communicate(RadiusRequest packet, RadiusEndpoint endpoint, int maxAttempts, int timeoutMillis, 
+            BiConsumer<Byte, InetSocketAddress> preSendHook, BiConsumer<Byte, InetSocketAddress> timeoutHook, 
+            BiConsumer<Byte, InetSocketAddress> postReceiveHook){
+        return communicate(packet, endpoint, new FixedTimeoutHandler(timer, maxAttempts, timeoutMillis), preSendHook, timeoutHook, postReceiveHook);
+    }
+
+    /**
+     * Sends packet to specified endpoint with the default timeoutHandler and no hooks.
+     * @param packet   packet to send
+     * @param endpoint endpoint to send packet to
+     * @return
+     */
+    public Future<RadiusResponse> communicate(RadiusRequest packet, RadiusEndpoint endpoint){
+        return communicate(packet, endpoint, timeoutHandler, null, null, null);
+    }
+
+    private void send(PendingRequestCtx ctx, int attempt, TimeoutHandler timeoutHandler, BiConsumer<Byte, InetSocketAddress> preSendHook, BiConsumer<Byte, InetSocketAddress> timeoutHook){
+        // More appropriate to use debug than info
+        log.debug("Attempt {}, sending packet to {}", attempt, ctx.getEndpoint().getAddress());
+        
+        // Report send packet to hook
+        if(preSendHook != null) preSendHook.accept(ctx.getRequest().getType(), ctx.getEndpoint().getAddress());
         channelFuture.channel().writeAndFlush(ctx);
-        timeoutHandler.onTimeout(() -> send(ctx, attempt + 1), attempt, ctx.getResponse());
+
+        timeoutHandler.onTimeout(() -> {
+                // Report timeout with retry (not final) to hook
+                if(timeoutHook != null) timeoutHook.accept(ctx.getRequest().getType(), ctx.getEndpoint().getAddress());
+                send(ctx, attempt + 1, timeoutHandler, preSendHook, timeoutHook);
+            }, attempt, ctx.getResponse());
     }
 
     @Override

--- a/src/main/java/org/tinyradius/io/client/handler/PromiseAdapter.java
+++ b/src/main/java/org/tinyradius/io/client/handler/PromiseAdapter.java
@@ -87,7 +87,7 @@ public class PromiseAdapter extends MessageToMessageCodec<RadiusResponse, Pendin
             final RadiusResponse response = msg.decodeResponse(request.secret, request.auth)
                     .removeLastAttribute(PROXY_STATE);
 
-            log.info("Found request for response identifier {}, proxyState requestId '{}'",
+            log.debug("Found request for response identifier {}, proxyState requestId '{}'",
                     response.getId(), requestId);
             request.promise.trySuccess(response);
 

--- a/src/test/java/org/tinyradius/core/attribute/type/VendorSpecificAttributeTest.java
+++ b/src/test/java/org/tinyradius/core/attribute/type/VendorSpecificAttributeTest.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.tinyradius.core.RadiusPacketException;
 import org.tinyradius.core.dictionary.Dictionary;
 import org.tinyradius.core.dictionary.parser.DictionaryParser;
-import org.tinyradius.core.packet.request.AccessRequest;
-import org.tinyradius.core.packet.request.RadiusRequest;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;


### PR DESCRIPTION
# Feature: Attempts and timeout per request. Hooks for instrumentation of RadiusClient

## Justification for the usefulness of the feature

The `RadiusClient` object uses a `FixedTimeoutHandler` passed on creation which, as the name implies, uses the same values for `maxAttempts` and `timeoutMillis` for all requests. If using `Tinyradius-netty` as the core of a fully fledged radius server/proxy implementation, this poses a limitation, since it is usually desirable to have different values for those parameters for different upstream radius servers, while wanting to use the same `RadiusClient` instance.

In addition, also for a fully fledged radius server/proxy implementation, it is important to have metrics for packets sent/received/timed-out. The current implementation of `RadiusClient` implements iternally a retry strategy, so that applications using it cannot record the number of times a packet was sent to an upstream radius server.

## Rationale for the proposed implementation

One possiblity would be to change the `TimeoutHandler.onTimeout` interface method to include the value of the timeout, but that would require a relatively major change. An approach that only adds new methods to the `RadiusClient` has been followed, ensuring backwards compatiblity, and not needing to rewrite any tests (only adding new ones).

The modified `RadiusClient` has additional methods to:
- Create internally and use another TimeoutHandler, instead of using the one specified at instantiation time (which is used as default), with parametrizable `maxAttempts` and `timeoutMillis`. 
- Invoke Java functions ("hooks") when a packet is sent, when a packet is received and when a timeout is fired. Those "hooks" may be used by the external application to record radius client metrics. The hook has two parameters: the type (request in case of recording a sending or a timeout, response in case of recording a response), and the destination InetSocketAddress.

## Implementation

The signature of the enriched `communicate` method is as follows

```java
public Future<RadiusResponse> communicate(RadiusRequest packet, List<RadiusEndpoint> endpoints, int maxAttempts, int timeoutMillis,
            BiConsumer<Byte, InetSocketAddress> preSendHook, BiConsumer<Byte, InetSocketAddress> timeoutHook, 
            BiConsumer<Byte, InetSocketAddress> postReceiveHook)
```

Where `preSendHook` is invoked before sending the radius client request, `timeoutHook` is invoked when a timeout is fired, and `postReceiveHook` is invoked when a response is received, the `type` Byte parameter being the response type.

And also analogous versions for `communicate` for a single Endpoint, such as

```java
public Future<RadiusResponse> communicate(RadiusRequest packet, List<RadiusEndpoint> endpoints, int maxAttempts, int timeoutMillis,
            BiConsumer<Byte, InetSocketAddress> preSendHook, BiConsumer<Byte, InetSocketAddress> timeoutHook, 
            BiConsumer<Byte, InetSocketAddress> postReceiveHook)
```

The implementation is pretty trivial, the only issue being the long list of parameters. The Hooks could be condensed in a specific Class, as done in the testing, but we have preferred to avoid defining unnecessary new types.

## Note

Happy to work on any other approach you may suggest to implement similar functionality.


## One additional change

Moved from `info` to `debug` 
```java
log.info("Found request for response identifier {}, proxyState requestId '{}'",...)
```