### PR TITLE
UnsupportedOperationException: No class provided

### DIFF
--- a/src/main/java/org/tinyradius/core/attribute/AttributeHolder.java
+++ b/src/main/java/org/tinyradius/core/attribute/AttributeHolder.java
@@ -28,7 +28,7 @@ import org.tinyradius.core.dictionary.Vendor;
  */
 public interface AttributeHolder<T extends AttributeHolder<T>> {
 
-    Logger attrHolderLogger = LogManager.getLogger();
+    Logger attrHolderLogger = LogManager.getLogger(AttributeHolder.class);
 
     /**
      * Converts a list of attributes to a ByteBuf.

--- a/src/main/java/org/tinyradius/core/attribute/type/RadiusAttributeFactory.java
+++ b/src/main/java/org/tinyradius/core/attribute/type/RadiusAttributeFactory.java
@@ -18,7 +18,7 @@ import org.tinyradius.core.dictionary.Vendor;
  */
 public interface RadiusAttributeFactory<T extends RadiusAttribute> {
 
-    Logger log = LogManager.getLogger();
+    Logger log = LogManager.getLogger(RadiusAttributeFactory.class);
 
     /**
      * Creates a new instance of the attribute.

--- a/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
+++ b/src/main/java/org/tinyradius/core/packet/request/AccessRequest.java
@@ -26,7 +26,7 @@ public abstract class AccessRequest extends GenericRequest implements MessageAut
     /**
      * Logger for this class.
      */
-    protected static final Logger logger = LogManager.getLogger();
+    protected static final Logger logger = LogManager.getLogger(AccessRequest.class);
 
     /**
      * Secure random number generator.

--- a/src/main/java/org/tinyradius/core/packet/util/MessageAuthSupport.java
+++ b/src/main/java/org/tinyradius/core/packet/util/MessageAuthSupport.java
@@ -26,7 +26,7 @@ import static org.tinyradius.core.attribute.codec.AttributeCodecType.NO_ENCRYPT;
  */
 public interface MessageAuthSupport<T extends RadiusPacket<T>> extends RadiusPacket<T> {
 
-    Logger msgAuthLogger = LogManager.getLogger();
+    Logger msgAuthLogger = LogManager.getLogger(MessageAuthSupport.class);
 
     private static byte[] calcMessageAuthInput(RadiusPacket<?> packet, byte[] requestAuth) {
         var buf = Unpooled.buffer()


### PR DESCRIPTION
Declared as interface . Under Keycloak's log4j2-jboss-logmanager, the first code
path that triggers its will throw the same UnsupportedOperationException: No class provided.